### PR TITLE
Error Saving Case After Upgrading CiviCRM Core To 4.7.30+

### DIFF
--- a/CRM/Prospect/ProspectCustomGroups.php
+++ b/CRM/Prospect/ProspectCustomGroups.php
@@ -203,9 +203,16 @@ class CRM_Prospect_ProspectCustomGroups {
     // So if the field's type is Date then we need to pick its value
     // from Request array and then convert it into CiviCRM date format.
     if ($dataType === 'Date') {
-      $dateArray = [
-        'value' => CRM_Utils_Request::getValue($fieldKey, CRM_Utils_Request::exportValues()),
-      ];
+      if(method_exists(CRM_Utils_Request, 'retrieveValue')) {
+        $dateArray = [
+          'value' => CRM_Utils_Request::retrieveValue($fieldKey, 'String', NULL, FALSE, CRM_Utils_Request::exportValues()),
+        ];
+      }
+      else {
+        $dateArray = [
+          'value' => CRM_Utils_Request::getValue($fieldKey, CRM_Utils_Request::exportValues()),
+        ];
+      }
 
       CRM_Utils_Date::convertToDefaultDate($dateArray, 1, 'value');
 


### PR DESCRIPTION
## Overview ##
We get a 500 error after upgrading to civicrm 4.7.30+

## Resolution ##
On looking into the code, there is a method used in this extension is made protected and a new public method is made available.
Call retrieveValue() instead of getValue() method if retrieveMethod() exists.
