### PR TITLE
GS-129: Implement Handling of Contribution Changes 

### DIFF
--- a/CRM/Prospect/BAO/ProspectConverted.php
+++ b/CRM/Prospect/BAO/ProspectConverted.php
@@ -55,6 +55,7 @@ class CRM_Prospect_BAO_ProspectConverted extends CRM_Prospect_DAO_ProspectConver
       'payment_entity' => NULL,
       'payment_entity_id' => NULL,
       'payment_url' => NULL,
+      'payment_status' => NULL,
     ];
 
     switch ($this->payment_type_id) {
@@ -66,6 +67,7 @@ class CRM_Prospect_BAO_ProspectConverted extends CRM_Prospect_DAO_ProspectConver
         }
 
         $result['payment_completed'] = $contribution['total_amount'];
+        $result['payment_status'] = $contribution['contribution_status'];
         $result['payment_entity'] = 'contribute';
         $result['payment_url'] = '/civicrm/contact/view/contribution?reset=1&id=' . $this->payment_entity_id . '&action=view&context=contribution&selectedChild=contribute';
       break;

--- a/CRM/Prospect/Hook/Post/Contribution.php
+++ b/CRM/Prospect/Hook/Post/Contribution.php
@@ -1,0 +1,213 @@
+<?php
+
+class CRM_Prospect_Hook_Post_Contribution {
+
+  /**
+   * Operation being performed on the record.
+   *
+   * @var string
+   */
+  private $op;
+
+  /**
+   * ID of the contribution.
+   *
+   * @var int
+   */
+  private $contributionID;
+
+  /**
+   * DAO of the contribution.
+   *
+   * @var \CRM_Contribute_DAO_Contribution
+   */
+  private $contributionDAO;
+
+  /**
+   * Array mapping contribution status ID's to status names.
+   *
+   * @var
+   */
+  private static $contributionStatuses = [];
+
+  /**
+   * CRM_Prospect_Hook_Post_Contribution constructor.
+   *
+   * @param string $op
+   * @param int $objectId
+   * @param \CRM_Contribute_DAO_Contribution $objectRef
+   */
+  public function __construct($op, $objectId, &$objectRef) {
+    $this->op = $op;
+    $this->contributionID = $objectId;
+    $this->contributionDAO = $objectRef;
+
+    $this->loadContributionStatusMap();
+  }
+
+  /**
+   * creates an array mapping contribution status ID's to status names.
+   */
+  private function loadContributionStatusMap() {
+    if (empty(self::$contributionStatuses)) {
+      $contributionStatuses = civicrm_api3('OptionValue', 'get', [
+        'sequential' => 1,
+        'return' => ['name', 'value'],
+        'option_group_id' => 'contribution_status',
+        'options' => ['limit' => 0],
+      ])['values'];
+
+      foreach ($contributionStatuses as $status) {
+        $contributionStatusesNameMap[$status['value']] = $status['name'];
+      }
+
+      self::$contributionStatuses = $contributionStatusesNameMap;
+    }
+  }
+
+  /**
+   * Processes hook.
+   */
+  public function runHook() {
+    switch ($this->op) {
+      case 'create':
+        $this->handleCreation();
+        break;
+      case 'edit':
+        $this->handleUpdate();
+        break;
+      case 'delete':
+        $this->handleDeletion();
+        break;
+    }
+  }
+
+  /**
+   * Handles contribution updates.
+   */
+  private function handleUpdate() {
+    $this->processContributionStatus();
+  }
+
+  /**
+   * Processe contribution status to update prospects' information.
+   */
+  private function processContributionStatus() {
+    $contributionStatusName = self::$contributionStatuses[$this->contributionDAO->contribution_status_id];
+
+    switch ($contributionStatusName) {
+      case 'Completed':
+      case 'Chargeback':
+        $this->setPaymentsOK();
+        break;
+
+      case 'In Progress':
+      case 'Overdue':
+      case 'Partially paid':
+      case 'Pending':
+      case 'Pending refund':
+        $this->setProspectAmountsFromContribution();
+        break;
+
+      case 'Cancelled':
+      case 'Failed':
+      case 'Refunded':
+        $this->deletePayments();
+        break;
+    }
+  }
+
+  /**
+   * Uses contribution data to recalculate Prospect_Amount and Expectation.
+   */
+  private function setProspectAmountsFromContribution() {
+    $prospectConversion = new CRM_Prospect_BAO_ProspectConverted();
+    $prospectConversion->payment_entity_id = $this->contributionID;
+    $prospectConversion->payment_type_id = CRM_Prospect_BAO_ProspectConverted::PAYMENT_TYPE_CONTRIBUTION;
+    $prospectConversion->find();
+
+    while ($prospectConversion->fetch()) {
+      $fields = new CRM_Prospect_prospectFinancialInformationFields($prospectConversion->prospect_case_id);
+      $fields->setValueOf('Prospect_Amount', $this->contributionDAO->total_amount);
+      $fields->updateExpectation();
+    }
+  }
+
+  /**
+   * If Case Id is passed through New Contribution / Pledge form then it means
+   * that the entity is asked to be converted by Prospect form.
+   *
+   * Creates ProspectConverted entity with specified payment entity, payment type
+   * and Case Id.
+   */
+  private function handleCreation() {
+    $caseId = CRM_Utils_Request::retrieve('caseId', 'Integer');
+    $paymentEntityId = $this->contributionID;
+    $paymentTypeId = CRM_Prospect_BAO_ProspectConverted::PAYMENT_TYPE_CONTRIBUTION;
+
+    if (!$caseId) {
+      return;
+    }
+
+    $prospectConverted = CRM_Prospect_BAO_ProspectConverted::findByCaseID($caseId);
+    if (!empty($prospectConverted)) {
+      return;
+    }
+
+    CRM_Prospect_BAO_ProspectConverted::create([
+      'prospect_case_id' => $caseId,
+      'payment_entity_id' => $paymentEntityId,
+      'payment_type_id' => $paymentTypeId,
+    ]);
+
+    $this->processContributionStatus();
+  }
+
+  /**
+   * Updates prospect amounts to reflect the payment done.
+   */
+  private function setPaymentsOK() {
+    $prospectConversion = new CRM_Prospect_BAO_ProspectConverted();
+    $prospectConversion->payment_entity_id = $this->contributionID;
+    $prospectConversion->payment_type_id = CRM_Prospect_BAO_ProspectConverted::PAYMENT_TYPE_CONTRIBUTION;
+    $prospectConversion->find();
+
+    while ($prospectConversion->fetch()) {
+      $caseId = $prospectConversion->prospect_case_id;
+      $fields = new CRM_Prospect_prospectFinancialInformationFields($caseId);
+
+      // Sets (Prospect Amount) value to 0.
+      $fields->setValueOf('Prospect_Amount', 0);
+
+      // Sets (Expectation) value to 0.
+      $fields->setValueOf('Expectation', 0);
+    }
+  }
+
+  /**
+   * Deletes payments associated to the current contribution.
+   */
+  private function deletePayments() {
+    $prospectConversion = new CRM_Prospect_BAO_ProspectConverted();
+    $prospectConversion->payment_entity_id = $this->contributionID;
+    $prospectConversion->payment_type_id = CRM_Prospect_BAO_ProspectConverted::PAYMENT_TYPE_CONTRIBUTION;
+    $prospectConversion->find();
+
+    while ($prospectConversion->fetch()) {
+      $fields = new CRM_Prospect_prospectFinancialInformationFields($prospectConversion->prospect_case_id);
+      $fields->setValueOf('Prospect_Amount', $this->contributionDAO->total_amount);
+      $fields->updateExpectation();
+
+      $prospectConversion->delete();
+    }
+  }
+
+  /**
+   * If contribution is deleted and it is associated to a converted prospect, it
+   * should also be deleted and prospect amount and expectation should be reset.
+   */
+  private function handleDeletion() {
+    $this->deletePayments();
+  }
+
+}

--- a/CRM/Prospect/ProspectCustomGroups.php
+++ b/CRM/Prospect/ProspectCustomGroups.php
@@ -232,7 +232,7 @@ class CRM_Prospect_ProspectCustomGroups {
       }
       else {
         $dateArray = [
-          'value' => CRM_Utils_Request::getValue($fieldKey, CRM_Utils_Request::exportValues()),
+          'value' => CRM_Utils_Array::value($fieldKey, CRM_Utils_Request::exportValues()),
         ];
       }
 

--- a/prospect.php
+++ b/prospect.php
@@ -250,7 +250,8 @@ function _prospect_civicrm_post_case($op, $objectId, &$objectRef) {
  * @param object $objectRef
  */
 function _prospect_civicrm_post_contribution($op, $objectId, &$objectRef) {
-  _prospect_civicrm_convert($objectId, CRM_Prospect_BAO_ProspectConverted::PAYMENT_TYPE_CONTRIBUTION);
+  $contributionPostHook = new CRM_Prospect_Hook_Post_Contribution($op, $objectId, $objectRef);
+  $contributionPostHook->runHook();
 }
 
 /**
@@ -276,30 +277,6 @@ function _prospect_civicrm_post_pledge($op, $objectId, &$objectRef) {
  * @param int $paymentTypeId
  */
 function _prospect_civicrm_convert($paymentEntityId, $paymentTypeId) {
-  $caseId = CRM_Utils_Request::retrieve('caseId', 'Integer');
-
-  if (!$caseId) {
-    return;
-  }
-
-  $prospectConverted = CRM_Prospect_BAO_ProspectConverted::findByCaseID($caseId);
-  if (!empty($prospectConverted)) {
-    return;
-  }
-
-  $fields = new CRM_Prospect_prospectFinancialInformationFields($caseId);
-
-  CRM_Prospect_BAO_ProspectConverted::create([
-    'prospect_case_id' => $caseId,
-    'payment_entity_id' => $paymentEntityId,
-    'payment_type_id' => $paymentTypeId,
-  ]);
-
-  // Sets (Prospect Amount) value to 0.
-  $fields->setValueOf('Prospect_Amount', 0);
-
-  // Sets (Expectation) value to 0.
-  $fields->setValueOf('Expectation', 0);
 }
 
 /**

--- a/prospect.php
+++ b/prospect.php
@@ -277,6 +277,30 @@ function _prospect_civicrm_post_pledge($op, $objectId, &$objectRef) {
  * @param int $paymentTypeId
  */
 function _prospect_civicrm_convert($paymentEntityId, $paymentTypeId) {
+  $caseId = CRM_Utils_Request::retrieve('caseId', 'Integer');
+
+  if (!$caseId) {
+    return;
+  }
+
+  $prospectConverted = CRM_Prospect_BAO_ProspectConverted::findByCaseID($caseId);
+  if (!empty($prospectConverted)) {
+    return;
+  }
+
+  $fields = new CRM_Prospect_prospectFinancialInformationFields($caseId);
+
+  CRM_Prospect_BAO_ProspectConverted::create([
+    'prospect_case_id' => $caseId,
+    'payment_entity_id' => $paymentEntityId,
+    'payment_type_id' => $paymentTypeId,
+  ]);
+
+  // Sets (Prospect Amount) value to 0.
+  $fields->setValueOf('Prospect_Amount', 0);
+
+  // Sets (Expectation) value to 0.
+  $fields->setValueOf('Expectation', 0);
 }
 
 /**

--- a/templates/CRM/Case/Page/Tab.extra.tpl
+++ b/templates/CRM/Case/Page/Tab.extra.tpl
@@ -52,7 +52,8 @@
             <div class="converted-case-payment-info">
               {if $paymentInfo.payment_completed}
                 <div class="payment-completed">
-                  {ts}Payment completed{/ts}: <span>{$paymentInfo.payment_completed}</span>
+
+                  {ts}Payment {$paymentInfo.payment_status}:{/ts} <span>{$paymentInfo.payment_completed}</span>
                 </div>
               {/if}
               {if $paymentInfo.pledge_balance}


### PR DESCRIPTION
## Overview
Greenhouse Sports have reported that a contribution they made that has been refunded still shows as part of their 'contribution total' column in the prospect pivot report. Upon closer inspection, the 'manage prospect' page of the prospect extension shows that the whole prospect does not recognise the change in contribution status. We need to fix this so that if a refund is issued then the refund is accounted for. We should also ensure that any other contribution status is correctly reflected in the prospect report. The expected behaviour is that a refunded payment is not included in the total contribution.

## Before
No matter the status of the contribution associated to a prospect, it was always being shown as completed.

## After
Added logic to the template showing the contribution to include the current status of the contribution. Also added functionality so the prospect and expected amounts change to 0 only if the contribution's status is completed. Finally, added functionality to delete the case/contribution relationship when the contribution is deleted. Also deleted the relationship on contribution refund, as the total should not be accounted for the prospect.

![gs-129-after](https://user-images.githubusercontent.com/21999940/39372654-97d56be8-4a0a-11e8-8adc-703a82a8c4d6.gif)
