### PR TITLE
GS-160: Fixed Warning message display on difference pages. 

### DIFF
--- a/CRM/Prospect/ProspectCustomGroups.php
+++ b/CRM/Prospect/ProspectCustomGroups.php
@@ -225,7 +225,7 @@ class CRM_Prospect_ProspectCustomGroups {
     // So if the field's type is Date then we need to pick its value
     // from Request array and then convert it into CiviCRM date format.
     if ($dataType === 'Date') {
-      if(method_exists(CRM_Utils_Request, 'retrieveValue')) {
+      if(method_exists(new CRM_Utils_Request(), 'retrieveValue')) {
         $dateArray = [
           'value' => CRM_Utils_Request::retrieveValue($fieldKey, 'String', NULL, FALSE, CRM_Utils_Request::exportValues()),
         ];

--- a/prospect.php
+++ b/prospect.php
@@ -201,7 +201,7 @@ function prospect_civicrm_post($op, $objectName, $objectId, &$objectRef) {
     return;
   }
 
-  call_user_func_array($postFunction, [$op, $objectId, $objectRef]);
+  call_user_func_array($postFunction, [$op, $objectId, &$objectRef]);
 }
 
 /**
@@ -323,7 +323,7 @@ function prospect_civicrm_alterTemplateFile($formName, &$form, $context, &$tplNa
     return;
   }
 
-  call_user_func_array($functionName, [$formName, &$form, $context, $tplName]);
+  call_user_func_array($functionName, [$formName, &$form, $context, &$tplName]);
 }
 
 /**


### PR DESCRIPTION
## Overview
This PR is fixed warning message display on difference pages when running on PHP 7.2

## Before

When create a new contribution.
![NewContribution_0628](https://user-images.githubusercontent.com/208713/60655017-f52f6700-9e44-11e9-90ac-b25c57547599.png)

When save contribution.
![Warning_SaveContribution](https://user-images.githubusercontent.com/208713/60654939-d03af400-9e44-11e9-9a99-60bcab888330.jpg)

When save prospect.
![Warning_SaveProspect](https://user-images.githubusercontent.com/208713/60655000-efd21c80-9e44-11e9-8066-92300c9a6d42.jpg)

## After

When create a new contribution
![Screenshot 2019-07-04 at 10 05 34](https://user-images.githubusercontent.com/208713/60655072-0a0bfa80-9e45-11e9-8a40-b5b249875e0d.png)

When save contribution
![Screenshot 2019-07-04 at 10 19 44](https://user-images.githubusercontent.com/208713/60655226-4ccdd280-9e45-11e9-9d6a-43d7800eb544.png)

When save prospects.
![Screenshot 2019-07-04 at 10 05 53](https://user-images.githubusercontent.com/208713/60655117-1f812480-9e45-11e9-90f4-27d51dac1902.png)


## Technical Details

1. The fixed the references expected, value given by passing reference value to function.
2. method_exists function was used to check if function is exist, however the function was passed Class instead of object so the warning appear. 



