### PR TITLE
RSE-179: Create Prospecting Case Type Category

### DIFF
--- a/CRM/Prospect/Setup/CreateProspectingOptionValue.php
+++ b/CRM/Prospect/Setup/CreateProspectingOptionValue.php
@@ -1,0 +1,22 @@
+<?php
+
+class CRM_Prospect_Setup_CreateProspectingOptionValue {
+
+  /**
+   * Creates the Prospecting option as a case type category option group
+   *
+   * @return bool
+   */
+  public function apply() {
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'case_type_categories',
+      'name' => 'Prospecting',
+      'label' => 'Prospecting',
+      'is_default' => 1,
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+
+    return TRUE;
+  }
+}

--- a/CRM/Prospect/Upgrader.php
+++ b/CRM/Prospect/Upgrader.php
@@ -94,4 +94,95 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
       [ 1 => [ $newStatus, 'Integer' ] ]
     );
   }
+
+  /**
+   * @inheritdoc
+   */
+  public function hasPendingRevisions() {
+    $revisions = $this->getRevisions();
+    $currentRevisionNum = $this->getCurrentRevision();
+    if (empty($revisions)) {
+      return FALSE;
+    }
+    if (empty($currentRevisionNum)) {
+      return TRUE;
+    }
+    return ($currentRevisionNum < max(array_keys($revisions)));
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function enqueuePendingRevisions(CRM_Queue_Queue $queue) {
+    $currentRevisionNum = (int) $this->getCurrentRevision();
+    foreach ($this->getRevisions() as $revisionNum => $revisionClass) {
+      if ($revisionNum < $currentRevisionNum) {
+        continue;
+      }
+      $tsParams = [1 => $this->extensionName, 2 => $revisionNum];
+      $title = ts('Upgrade %1 to revision %2', $tsParams);
+      $upgradeTask = new CRM_Queue_Task(
+        [get_class($this), 'runStepUpgrade'],
+        [(new $revisionClass())],
+        $title
+      );
+      $queue->createItem($upgradeTask);
+      $setRevisionTask = new CRM_Queue_Task(
+        [get_class($this), '_queueAdapter'],
+        ['setCurrentRevision', $revisionNum],
+        $title
+      );
+      $queue->createItem($setRevisionTask);
+    }
+  }
+
+  /**
+   * This is a callback for running step upgraders from the queue
+   *
+   * @param CRM_Queue_TaskContext $context
+   * @param \object $step
+   *
+   * @return true
+   *   The queue requires that true is returned on successful upgrade, but we
+   *   use exceptions to indicate an error instead.
+   */
+  public function runStepUpgrade($context, $step) {
+    $step->apply();
+    return TRUE;
+  }
+
+  /**
+   * Get a list of revisions.
+   *
+   * @return array
+   *   An array of revision classes sorted numerically by their key
+   */
+  public function getRevisions() {
+    $extensionRoot = __DIR__;
+    $stepClassFiles = glob($extensionRoot . '/Upgrader/Steps/Step*.php');
+    $sortedKeyedClasses = [];
+    foreach ($stepClassFiles as $file) {
+      $class = $this->getUpgraderClassnameFromFile($file);
+      $numberPrefix = 'Steps_Step';
+      $startPos = strpos($class, $numberPrefix) + strlen($numberPrefix);
+      $revisionNum = (int) substr($class, $startPos);
+      $sortedKeyedClasses[$revisionNum] = $class;
+    }
+    ksort($sortedKeyedClasses, SORT_NUMERIC);
+    return $sortedKeyedClasses;
+  }
+
+  /**
+   * Gets the PEAR style classname from an upgrader file
+   *
+   * @param string $file
+   *
+   * @return string
+   */
+  private function getUpgraderClassnameFromFile($file) {
+    $file = str_replace(realpath(__DIR__ . '/../../'), '', $file);
+    $file = str_replace('.php', '', $file);
+    $file = str_replace('/', '_', $file);
+    return ltrim($file, '_');
+  }
 }

--- a/CRM/Prospect/Upgrader.php
+++ b/CRM/Prospect/Upgrader.php
@@ -122,6 +122,7 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
     if (empty($currentRevisionNum)) {
       return TRUE;
     }
+
     return ($currentRevisionNum < max(array_keys($revisions)));
   }
 
@@ -163,6 +164,7 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
    */
   public function runStepUpgrade($context, $step) {
     $step->apply();
+
     return TRUE;
   }
 
@@ -184,6 +186,7 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
       $sortedKeyedClasses[$revisionNum] = $class;
     }
     ksort($sortedKeyedClasses, SORT_NUMERIC);
+
     return $sortedKeyedClasses;
   }
 
@@ -198,6 +201,7 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
     $file = str_replace(realpath(__DIR__ . '/../../'), '', $file);
     $file = str_replace('.php', '', $file);
     $file = str_replace('/', '_', $file);
+
     return ltrim($file, '_');
   }
 }

--- a/CRM/Prospect/Upgrader.php
+++ b/CRM/Prospect/Upgrader.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Prospect_Setup_CreateProspectingOptionValue as CreateProspectingOptionValue;
+
 /**
  * Collection of upgrade steps.
  */
@@ -41,6 +43,19 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
    */
   public function disable() {
     $this->toggleDefaulValues(0);
+  }
+
+  /**
+   * Tasks to perform when the module is installed.
+   */
+  public function install() {
+    $steps = [
+      new CreateProspectingOptionValue(),
+    ];
+
+    foreach ($steps as $step) {
+      $step->apply();
+    }
   }
 
   /**

--- a/CRM/Prospect/Upgrader/Base.php
+++ b/CRM/Prospect/Upgrader/Base.php
@@ -1,6 +1,7 @@
 <?php
 
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+use CRM_Prospect_ExtensionUtil as E;
 
 /**
  * Base class which provides helpers to execute upgrade logic
@@ -8,7 +9,7 @@
 class CRM_Prospect_Upgrader_Base {
 
   /**
-   * @var varies, subclass of ttis
+   * @var varies, subclass of this
    */
   static $instance;
 

--- a/CRM/Prospect/Upgrader/Steps/Step1001.php
+++ b/CRM/Prospect/Upgrader/Steps/Step1001.php
@@ -1,0 +1,18 @@
+<?php
+
+use CRM_Prospect_Setup_CreateProspectingOptionValue as CreateProspectingOptionValue;
+
+class CRM_Prospect_Upgrader_Steps_Step1001 {
+
+  /**
+   * Creates the Prospecting option as a case type category option group
+   *
+   * @return bool
+   */
+  public function apply() {
+    $step = new CreateProspectingOptionValue();
+    $step->apply();
+
+    return TRUE;
+  }
+}

--- a/prospect.civix.php
+++ b/prospect.civix.php
@@ -3,6 +3,83 @@
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Prospect_ExtensionUtil {
+  const SHORT_NAME = "prospect";
+  const LONG_NAME = "uk.co.compucorp.civicrm.prospect";
+  const CLASS_PREFIX = "CRM_Prospect";
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = array()) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = array(self::LONG_NAME, NULL);
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_Prospect_ExtensionUtil as E;
+
+/**
  * (Delegated) Implements hook_civicrm_config().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
@@ -186,16 +263,17 @@ function _prospect_civix_find_files($dir, $pattern) {
  */
 function _prospect_civix_civicrm_managed(&$entities) {
   $mgdFiles = _prospect_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
   foreach ($mgdFiles as $file) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = 'uk.co.compucorp.civicrm.prospect';
+        $e['module'] = E::LONG_NAME;
       }
-      $entities[] = $e;
       if (empty($e['params']['version'])) {
         $e['params']['version'] = '3';
       }
+      $entities[] = $e;
     }
   }
 }
@@ -222,7 +300,7 @@ function _prospect_civix_civicrm_caseTypes(&$caseTypes) {
       // throw new CRM_Core_Exception($errorMessage);
     }
     $caseTypes[$name] = array(
-      'module' => 'uk.co.compucorp.civicrm.prospect',
+      'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
     );
@@ -248,7 +326,7 @@ function _prospect_civix_civicrm_angularModules(&$angularModules) {
     $name = preg_replace(':\.ang\.php$:', '', basename($file));
     $module = include $file;
     if (empty($module['ext'])) {
-      $module['ext'] = 'uk.co.compucorp.civicrm.prospect';
+      $module['ext'] = E::LONG_NAME;
     }
     $angularModules[$name] = $module;
   }
@@ -275,8 +353,10 @@ function _prospect_civix_glob($pattern) {
  * Inserts a navigation menu item at a given place in the hierarchy.
  *
  * @param array $menu - menu hierarchy
- * @param string $path - path where insertion should happen (ie. Administer/System Settings)
- * @param array $item - menu you need to insert (parent/child attributes will be filled for you)
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
  */
 function _prospect_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
@@ -365,4 +445,23 @@ function _prospect_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) 
   if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
     $metaDataFolders[] = $settingsDir;
   }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ */
+
+function _prospect_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, array (
+    'CRM_Prospect_DAO_ProspectConverted' => 
+    array (
+      'name' => 'ProspectConverted',
+      'class' => 'CRM_Prospect_DAO_ProspectConverted',
+      'table' => 'civicrm_prospect_converted',
+    ),
+  ));
 }


### PR DESCRIPTION
## Overview
This PR adds the `Prospecting` as an option value for the case type category option group upon installation of the prospects extension and also via upgraders when the extension is already installed on a site.

## Before
The Prospecting case type category option value does not exist

## After
The Prospecting case type category option value is added
<img width="1278" alt="Option Groups  case-prospect 2019-07-10 16-11-41" src="https://user-images.githubusercontent.com/6951813/60981066-8a42cc00-a32d-11e9-94b6-fee683339ed5.png">



## Comments
A few other things was also done in this PR:

- An error when installing the prospect extension for the first time due to a missing class was fixed.
- Making the Upgrader class compatible with the new way for writing upgraders described [here](https://compucorp.atlassian.net/wiki/spaces/PCHR/pages/835092529/Add+a+CiviCRM+Upgrader) 
- Upgrading the prospect.civix.php file with `civix: generate upgraders`