### PR TITLE
RSE-169: Create Prospect Menu

### DIFF
--- a/CRM/Prospect/Setup/CreateProspectMenus.php
+++ b/CRM/Prospect/Setup/CreateProspectMenus.php
@@ -1,0 +1,90 @@
+<?php
+
+class CRM_Prospect_Setup_CreateProspectMenus {
+
+  /**
+   * Creates the Prospect menu items
+   *
+   * @return bool
+   */
+  public function apply() {
+    $this->createProspectMenuItems();
+
+    return TRUE;
+  }
+
+  /**
+   * Creates Prospect Main menu.
+   */
+  private function createProspectMenuItems() {
+    $result = civicrm_api3('Navigation', 'get', ['name' => 'prospects']);
+
+    if ($result['count'] > 0) {
+      return;
+    }
+
+    $casesWeight = CRM_Core_DAO::getFieldValue(
+      'CRM_Core_DAO_Navigation',
+      'Cases',
+      'weight',
+      'name'
+    );
+
+    $params = [
+      'label' => ts('Prospects'),
+      'name' => 'prospects',
+      'url' => NULL,
+      'permission_operator' => 'OR',
+      'is_active' => 1,
+      'permission' => 'access my cases and activities,access all cases and activities',
+      'icon' => 'crm-i fa-folder-open-o'
+    ];
+
+    $prospectMenu = civicrm_api3('Navigation', 'create', $params);
+    //Menu weight seems to be ignored on create irrespective of whatever is passed, Civi
+    //will assign the next available weight. This fixes the issue.
+    civicrm_api3('Navigation', 'create', [
+        'id' => $prospectMenu['id'],
+        'weight' => $casesWeight + 1]
+    );
+    $this->createProspectSubmenus($prospectMenu['id']);
+  }
+
+  /**
+   * Creates Prospect sub menu items.
+   *
+   * @param int $prospectMenuId
+   */
+  private function createProspectSubmenus($prospectMenuId) {
+    $submenus = [
+      [
+        'label' => ts('Dashboard'),
+        'name' => 'prospect_dashboard',
+        'url' => 'civicrm/case/a/#/case?category=prospect',
+        'permission' => 'access my cases and activities,access all cases and activities',
+        'permission_operator' => 'OR',
+      ],
+      [
+        'label' => ts('New Prospect'),
+        'name' => 'new_prospect',
+        'url' => 'civicrm/case/add?category=prospect',
+        'permission' => 'add cases,access all cases and activities',
+        'permission_operator' => 'OR',
+      ],
+      [
+        'label' => ts('Manage Prospects'),
+        'name' => 'manage_prospect',
+        'url' => 'civicrm/case/a/#/case/list?category=prospect',
+        'permission' => 'access my cases and activities,access all cases and activities',
+        'permission_operator' => 'OR',
+      ],
+    ];
+
+    foreach ($submenus as $i => $item) {
+      $item['weight'] = $i;
+      $item['parent_id'] = $prospectMenuId;
+      $item['is_active'] = 1;
+      civicrm_api3('Navigation', 'create', $item);
+    }
+  }
+}

--- a/CRM/Prospect/Upgrader.php
+++ b/CRM/Prospect/Upgrader.php
@@ -134,7 +134,8 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
   public function enqueuePendingRevisions(CRM_Queue_Queue $queue) {
     $currentRevisionNum = (int) $this->getCurrentRevision();
     foreach ($this->getRevisions() as $revisionNum => $revisionClass) {
-      if ($revisionNum < $currentRevisionNum) {
+
+      if ($revisionNum <= $currentRevisionNum) {
         continue;
       }
       $tsParams = [1 => $this->extensionName, 2 => $revisionNum];

--- a/CRM/Prospect/Upgrader.php
+++ b/CRM/Prospect/Upgrader.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_Prospect_Setup_CreateProspectingOptionValue as CreateProspectingOptionValue;
+use CRM_Prospect_Setup_CreateProspectMenus as CreateProspectMenus;
 
 /**
  * Collection of upgrade steps.
@@ -51,6 +52,7 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
   public function install() {
     $steps = [
       new CreateProspectingOptionValue(),
+      new CreateProspectMenus()
     ];
 
     foreach ($steps as $step) {

--- a/CRM/Prospect/Upgrader/Steps/Step1002.php
+++ b/CRM/Prospect/Upgrader/Steps/Step1002.php
@@ -1,0 +1,18 @@
+<?php
+
+use CRM_Prospect_Setup_CreateProspectMenus as CreateProspectMenus;
+
+class CRM_Prospect_Upgrader_Steps_Step1002 {
+
+  /**
+   * Creates the Prospect menu items
+   *
+   * @return bool
+   */
+  public function apply() {
+    $step = new CreateProspectMenus();
+    $step->apply();
+
+    return TRUE;
+  }
+}


### PR DESCRIPTION
## Overview
This PR creates the Prospect Main menu and sub menus. This menus are created upon installation or by running upgraders for sites with the extension already installed.

## Before
The Prospect menus does not exist.

## After
The prospect menus exists.
<img width="1280" alt="Monosnap 2019-07-11 11-48-48" src="https://user-images.githubusercontent.com/6951813/61061341-f38d1280-a3f3-11e9-94c4-e94d8f5eb995.png">

## Comments
This PR also fixes an issue with a function in the Upgrader file that allows the most recently ran upgrader to be ran again before running new upgraders. 