### PR TITLE
RSE-184: Change Prospecting Menu URLs

### DIFF
--- a/CRM/Prospect/Setup/CreateProspectMenus.php
+++ b/CRM/Prospect/Setup/CreateProspectMenus.php
@@ -1,11 +1,15 @@
 <?php
 
+/**
+ * Create Prospect Menu items.
+ */
 class CRM_Prospect_Setup_CreateProspectMenus {
 
   /**
-   * Creates the Prospect menu items
+   * Creates the Prospect menu items.
    *
    * @return bool
+   *   Returns TRUE
    */
   public function apply() {
     $this->createProspectMenuItems();
@@ -37,16 +41,16 @@ class CRM_Prospect_Setup_CreateProspectMenus {
       'permission_operator' => 'OR',
       'is_active' => 1,
       'permission' => 'access my cases and activities,access all cases and activities',
-      'icon' => 'crm-i fa-folder-open-o'
+      'icon' => 'crm-i fa-folder-open-o',
     ];
 
     $prospectMenu = civicrm_api3('Navigation', 'create', $params);
-    //Menu weight seems to be ignored on create irrespective of whatever is passed, Civi
-    //will assign the next available weight. This fixes the issue.
+    // Menu weight seems to be ignored on create irrespective of whatever is
+    // passed, Civi will assign the next available weight. This fixes the issue.
     civicrm_api3('Navigation', 'create', [
-        'id' => $prospectMenu['id'],
-        'weight' => $casesWeight + 1]
-    );
+      'id' => $prospectMenu['id'],
+      'weight' => $casesWeight + 1,
+    ]);
     $this->createProspectSubmenus($prospectMenu['id']);
   }
 
@@ -54,27 +58,28 @@ class CRM_Prospect_Setup_CreateProspectMenus {
    * Creates Prospect sub menu items.
    *
    * @param int $prospectMenuId
+   *   Prospect menu id.
    */
   private function createProspectSubmenus($prospectMenuId) {
     $submenus = [
       [
         'label' => ts('Dashboard'),
         'name' => 'prospect_dashboard',
-        'url' => 'civicrm/case/a/#/case?category=prospect',
+        'url' => 'civicrm/case/a/#/case?case_type_category=prospecting',
         'permission' => 'access my cases and activities,access all cases and activities',
         'permission_operator' => 'OR',
       ],
       [
         'label' => ts('New Prospect'),
         'name' => 'new_prospect',
-        'url' => 'civicrm/case/add?category=prospect',
+        'url' => 'civicrm/case/add?case_type_category=prospecting&action=add&reset=1&context=standalone',
         'permission' => 'add cases,access all cases and activities',
         'permission_operator' => 'OR',
       ],
       [
         'label' => ts('Manage Prospects'),
         'name' => 'manage_prospect',
-        'url' => 'civicrm/case/a/#/case/list?category=prospect',
+        'url' => 'civicrm/case/a/#/case/list?cf=%7B"case_type_category":"prospecting"%7D',
         'permission' => 'access my cases and activities,access all cases and activities',
         'permission_operator' => 'OR',
       ],
@@ -87,4 +92,5 @@ class CRM_Prospect_Setup_CreateProspectMenus {
       civicrm_api3('Navigation', 'create', $item);
     }
   }
+
 }


### PR DESCRIPTION
## Overview
As part of this PR, the Prospecting Menu items menu url has been changed.

## Before
Dashboard - `civicrm/case/a/#/case?category=prospect`
New Prospect - `civicrm/case/add?category=prospect`
Manage Prospects - `civicrm/case/a/#/case/list?category=prospect`

## After
Dashboard - `civicrm/case/a/#/case?case_type_category=prospecting`
New Prospect - `civicrm/case/add?case_type_category=prospecting&action=add&reset=1&context=standalone`
Manage Prospects - `civicrm/case/a/#/case/list?cf=%7B"case_type_category":"prospecting"%7D`

## Technical Details
1. The category key name has been changed to `case_type_category` to make to more clear.
2. For the Manage Screen page, the query string `case_type_category` is changed to
`cf=%7B"case_type_category":"prospecting"%7D'` to make it compatible with existing filtering.
The previous upgraders are updated, as it is not released yet. We will make changes in our local manually.
