### PR TITLE
RSE-231: Move Prospect Custom Fields to the Prospect Case Category

### DIFF
--- a/CRM/Prospect/Upgrader/Steps/Step1003.php
+++ b/CRM/Prospect/Upgrader/Steps/Step1003.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Migrates the Prospect Custom fields to the prospecting case category.
+ */
+class CRM_Prospect_Upgrader_Steps_Step1003 {
+
+  /**
+   * Migrates the Prospect Custom fields to the prospecting case category.
+   *
+   * @return bool
+   *   Return value in boolean.
+   */
+  public function apply() {
+    $prospectCustomroups = [
+      'Prospect_Financial_Information',
+      'Prospect_Substatus',
+    ];
+
+    $result = civicrm_api3('CustomGroup', 'get', [
+      'return' => ['id'],
+      'name' => ['IN' => $prospectCustomroups],
+      'extends' => 'Case',
+    ]);
+
+    if ($result['count'] == 0) {
+      return TRUE;
+    }
+
+    foreach ($result['values'] as $value) {
+      civicrm_api3('CustomGroup', 'create', [
+        'id' => $value['id'],
+        'extends' => 'prospecting',
+      ]);
+    }
+
+    return TRUE;
+  }
+
+}

--- a/CRM/Prospect/Upgrader/Steps/Step1003.php
+++ b/CRM/Prospect/Upgrader/Steps/Step1003.php
@@ -12,14 +12,14 @@ class CRM_Prospect_Upgrader_Steps_Step1003 {
    *   Return value in boolean.
    */
   public function apply() {
-    $prospectCustomroups = [
+    $prospectCustomGroups = [
       'Prospect_Financial_Information',
       'Prospect_Substatus',
     ];
 
     $result = civicrm_api3('CustomGroup', 'get', [
       'return' => ['id'],
-      'name' => ['IN' => $prospectCustomroups],
+      'name' => ['IN' => $prospectCustomGroups],
       'extends' => 'Case',
     ]);
 

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -7,5 +7,8 @@
     <!-- Hence the following rules are excluded -->
     <exclude name="Drupal.NamingConventions.ValidClassName.NoUnderscores"/>
     <exclude name="Drupal.Classes.ClassFileName.NoMatch"/>
+    <!--Drupal expects function names like civicase_civicrm_pre_process but civi can have-->
+    <!--civicase_civicrm_preProcess which is valid for civi.-->
+    <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
   </rule>
 </ruleset>

--- a/xml/custom_group_prospect_financial_information_install.xml
+++ b/xml/custom_group_prospect_financial_information_install.xml
@@ -5,7 +5,7 @@
     <CustomGroup>
       <name>Prospect_Financial_Information</name>
       <title>Financial Information</title>
-      <extends>Case</extends>
+      <extends>prospecting</extends>
       <style>Inline</style>
       <collapse_display>0</collapse_display>
       <weight>11</weight>

--- a/xml/custom_group_prospect_substatus_install.xml
+++ b/xml/custom_group_prospect_substatus_install.xml
@@ -5,7 +5,7 @@
     <CustomGroup>
       <name>Prospect_Substatus</name>
       <title>Substatus</title>
-      <extends>Case</extends>
+      <extends>prospecting</extends>
       <style>Inline</style>
       <collapse_display>0</collapse_display>
       <help_pre></help_pre>


### PR DESCRIPTION
## Overview
The Civi prospect extension comes pre-installed with a set of custom fields. This PR moves those custom fields to the prospect case category so that when the URL `civicrm/case/add?case_type_category=prospecting&action=add&reset=1&context=standalone` is viewed these custom fields will show up when adding a new prospect.

## Before
This functionality was not present.

## After
The Custom fields belonging to the `Prospect_Financial_Information` and `Prospect_Substatus` option groups now show up when adding a new prospect and does not show up for any other case category on the Add Case page.

## Technical Details
- An upgrader was created to move the custom fields to the Prospect case category for sites where the extension is already installed and the custom field XML file was modified for new sites to reflect the change.
