### PR TITLE
RSE-174: Refactor Function to Retrieve Prospect Custom Field Values when Calculating Expected Value

### DIFF
--- a/CRM/Prospect/ProspectCustomGroups.php
+++ b/CRM/Prospect/ProspectCustomGroups.php
@@ -269,12 +269,21 @@ class CRM_Prospect_ProspectCustomGroups {
     $customFieldData = $this->getCustomFieldData();
 
     if ($this->caseId) {
-      $caseProspectCustomValues = civicrm_api3('Case', 'getsingle', [
-        'id' => $this->caseId,
-        'return' => $this->getCustomFieldMachineNameList(),
-      ]);
-    }
+      $customFieldMachineNameList = $this->getCustomFieldMachineNameList();
+      $parameters = [
+        'entity_id' => $this->caseId,
+        'entity_type' => 'prospecting'
+      ];
+      foreach ($customFieldMachineNameList as $machineName) {
+        $parameters['return.' . $machineName] = 1;
+      }
+      $customValues = civicrm_api3('CustomValue', 'get', $parameters);
+      $caseProspectCustomValues = [];
 
+      foreach ($customValues['values'] as $customValue) {
+        $caseProspectCustomValues['custom_' . $customValue['id']] = $customValue['latest'];
+      }
+    }
 
     foreach ($customFieldData as $name => $value) {
       $this->fields[$name] = [


### PR DESCRIPTION
## Overview
After the prospect custom fields were moved to their own namespace in this PR (#25), the calculation for the Expected value stopped working and `0` was always recorder in the calculation irrespective of values of the `Prospect Amount` and `Probability` fields.


## Before
- The Expected value calculation was not working as expected.

## After
- The function for retrieving the values of the Prospect custom fields after it was saved to the database was refactored since these fields are no longer extending the `Case` entity but now extending the `Prospecting` entity for the custom group.

After the refactoring, the expected value calculation now works as expected:
```php
```