### PR TITLE
RSE-231: Move Prospect Custom Fields To Prospect Category

### DIFF
--- a/CRM/Prospect/Setup/AddProspectCategoryCgExtendsValue.php
+++ b/CRM/Prospect/Setup/AddProspectCategoryCgExtendsValue.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * CRM_Prospect_Setup_AddProspectCategoryCgExtendsValue class.
+ */
+class CRM_Prospect_Setup_AddProspectCategoryCgExtendsValue {
+
+  /**
+   * Add Prospecting as a valid Entity that a custom group can extend.
+   */
+  public function apply() {
+    $prospectCategoryLabel = 'Case (Prospects)';
+
+    $result = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'cg_extend_objects',
+      'label' => $prospectCategoryLabel,
+    ]);
+
+    if ($result['count'] > 0) {
+      return;
+    }
+
+    civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => 'cg_extend_objects',
+      'name' => 'civicrm_case',
+      'label' => $prospectCategoryLabel,
+      'value' => 'prospecting',
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+  }
+
+}

--- a/CRM/Prospect/Setup/MoveCustomFieldsToProspecting.php
+++ b/CRM/Prospect/Setup/MoveCustomFieldsToProspecting.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Moves prospect custom fields to prospect category type..
+ */
+class CRM_Prospect_Setup_MoveCustomFieldsToProspecting {
+
+  /**
+   * Migrates the Prospect Custom fields to the prospecting case category.
+   */
+  public function apply() {
+    $prospectCustomGroups = [
+      'Prospect_Financial_Information',
+      'Prospect_Substatus',
+    ];
+
+    $result = civicrm_api3('CustomGroup', 'get', [
+      'return' => ['id'],
+      'name' => ['IN' => $prospectCustomGroups],
+      'extends' => 'Case',
+    ]);
+
+    if ($result['count'] == 0) {
+      return TRUE;
+    }
+
+    foreach ($result['values'] as $value) {
+      civicrm_api3('CustomGroup', 'create', [
+        'id' => $value['id'],
+        'extends' => 'prospecting',
+      ]);
+    }
+  }
+
+}

--- a/CRM/Prospect/Upgrader.php
+++ b/CRM/Prospect/Upgrader.php
@@ -5,6 +5,7 @@ use CRM_Prospect_Setup_CreateProspectMenus as CreateProspectMenus;
 use CRM_Prospect_Setup_CreateProspectOwnerRelationship as CreateProspectOwnerRelationship;
 use CRM_Prospect_Setup_CreateProspectWorkflowCaseStatuses as CreateProspectWorkflowCaseStatuses;
 use CRM_Prospect_Setup_CreateProspectWorkflowCaseType as CreateProspectWorkflowCaseType;
+use CRM_Prospect_Setup_MoveCustomFieldsToProspecting as MoveCustomFieldsToProspecting;
 
 /**
  * Collection of upgrade steps.
@@ -59,6 +60,7 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
       new CreateProspectWorkflowCaseStatuses(),
       new CreateProspectOwnerRelationship(),
       new CreateProspectWorkflowCaseType(),
+      new MoveCustomFieldsToProspecting(),
     ];
 
     foreach ($steps as $step) {

--- a/CRM/Prospect/Upgrader.php
+++ b/CRM/Prospect/Upgrader.php
@@ -6,6 +6,7 @@ use CRM_Prospect_Setup_CreateProspectOwnerRelationship as CreateProspectOwnerRel
 use CRM_Prospect_Setup_CreateProspectWorkflowCaseStatuses as CreateProspectWorkflowCaseStatuses;
 use CRM_Prospect_Setup_CreateProspectWorkflowCaseType as CreateProspectWorkflowCaseType;
 use CRM_Prospect_Setup_MoveCustomFieldsToProspecting as MoveCustomFieldsToProspecting;
+use CRM_Prospect_Setup_AddProspectCategoryCgExtendsValue as AddProspectCategoryCgExtendsValue;
 
 /**
  * Collection of upgrade steps.
@@ -60,6 +61,7 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
       new CreateProspectWorkflowCaseStatuses(),
       new CreateProspectOwnerRelationship(),
       new CreateProspectWorkflowCaseType(),
+      new AddProspectCategoryCgExtendsValue(),
       new MoveCustomFieldsToProspecting(),
     ];
 

--- a/CRM/Prospect/Upgrader/Steps/Step1003.php
+++ b/CRM/Prospect/Upgrader/Steps/Step1003.php
@@ -1,0 +1,23 @@
+<?php
+
+use CRM_Prospect_Setup_MoveCustomFieldsToProspecting as MoveCustomFieldsToProspecting;
+
+/**
+ * Moves the prospect custom fields to the prospect category.
+ */
+class CRM_Prospect_Upgrader_Steps_Step1003 {
+
+  /**
+   * Moves the prospect custom fields to the prospect category.
+   *
+   * @return bool
+   *   Boolean value.
+   */
+  public function apply() {
+    $step = new MoveCustomFieldsToProspecting();
+    $step->apply();
+
+    return TRUE;
+  }
+
+}

--- a/CRM/Prospect/Upgrader/Steps/Step1003.php
+++ b/CRM/Prospect/Upgrader/Steps/Step1003.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_Prospect_Setup_AddProspectCategoryCgExtendsValue as AddProspectCategoryCgExtendsValue;
 use CRM_Prospect_Setup_MoveCustomFieldsToProspecting as MoveCustomFieldsToProspecting;
 
 /**
@@ -10,12 +11,20 @@ class CRM_Prospect_Upgrader_Steps_Step1003 {
   /**
    * Moves the prospect custom fields to the prospect category.
    *
+   * Adds the prospecting category as an extendable entity.
+   *
    * @return bool
    *   Boolean value.
    */
   public function apply() {
-    $step = new MoveCustomFieldsToProspecting();
-    $step->apply();
+    $steps = [
+      new AddProspectCategoryCgExtendsValue(),
+      new MoveCustomFieldsToProspecting(),
+    ];
+
+    foreach ($steps as $step) {
+      $step->apply();
+    }
 
     return TRUE;
   }


### PR DESCRIPTION
## Overview
This PR does adds back an upgrader that was mistakenly removed earlier. The Upgrader was supposed to add the Prospect Custom fields to the prospect case type category.
Also an upgrader that adds Prospect as an Entity that is extendable by a custom group was added in this PR. The upgrader was formally in the Civicase extension but the right place is actually the prospect extension.


## After
- Missing Upgrader that is responsible for adding the Prospect Custom fields to the prospect case type category was added back.
- An upgrader that adds Prospect as an extendable object for Custom groups was added.

