### PR TITLE
RSE-172: Add Grouping For Prospect Case Statuses

### DIFF
--- a/CRM/Prospect/Setup/CreateProspectWorkflowCaseStatuses.php
+++ b/CRM/Prospect/Setup/CreateProspectWorkflowCaseStatuses.php
@@ -16,6 +16,7 @@ class CRM_Prospect_Setup_CreateProspectWorkflowCaseStatuses {
         'option_group_id' => 'case_status',
         'name' => $caseStatus['name'],
         'label' => $caseStatus['label'],
+        'grouping' => $caseStatus['class'],
         'is_active' => TRUE,
         'is_reserved' => TRUE,
       ]);
@@ -30,12 +31,36 @@ class CRM_Prospect_Setup_CreateProspectWorkflowCaseStatuses {
    */
   public static function getStatuses() {
     $caseStatuses = [
-      ['name' => 'enquiry', 'label' => 'Enquiry (positive)'],
-      ['name' => 'qualified', 'label' => 'Qualified (positive)'],
-      ['name' => 'in_progress', 'label' => 'In progress (positive)'],
-      ['name' => 'submitted', 'label' => 'Submitted (positive)'],
-      ['name' => 'won', 'label' => 'Won (positive)'],
-      ['name' => 'lost', 'label' => 'Lost (negative)'],
+      [
+        'name' => 'enquiry',
+        'label' => 'Enquiry (positive)',
+        'class' => 'Opened',
+      ],
+      [
+        'name' => 'qualified',
+        'label' => 'Qualified (positive)',
+        'class' => 'Opened',
+      ],
+      [
+        'name' => 'in_progress',
+        'label' => 'In progress (positive)',
+        'class' => 'Opened',
+      ],
+      [
+        'name' => 'submitted',
+        'label' => 'Submitted (positive)',
+        'class' => 'Opened',
+      ],
+      [
+        'name' => 'won',
+        'label' => 'Won (positive)',
+        'class' => 'Closed',
+      ],
+      [
+        'name' => 'lost',
+        'label' => 'Lost (negative)',
+        'class' => 'Closed',
+      ],
     ];
 
     return $caseStatuses;

--- a/CRM/Prospect/Setup/CreateProspectWorkflowCaseStatuses.php
+++ b/CRM/Prospect/Setup/CreateProspectWorkflowCaseStatuses.php
@@ -30,36 +30,39 @@ class CRM_Prospect_Setup_CreateProspectWorkflowCaseStatuses {
    *   Workflow case statuses.
    */
   public static function getStatuses() {
+    $openCaseStatusClass = 'Opened';
+    $closedCaseStatusClass = 'Closed';
+
     $caseStatuses = [
       [
         'name' => 'enquiry',
         'label' => 'Enquiry (positive)',
-        'class' => 'Opened',
+        'class' => $openCaseStatusClass,
       ],
       [
         'name' => 'qualified',
         'label' => 'Qualified (positive)',
-        'class' => 'Opened',
+        'class' => $openCaseStatusClass,
       ],
       [
         'name' => 'in_progress',
         'label' => 'In progress (positive)',
-        'class' => 'Opened',
+        'class' => $openCaseStatusClass,
       ],
       [
         'name' => 'submitted',
         'label' => 'Submitted (positive)',
-        'class' => 'Opened',
+        'class' => $openCaseStatusClass,
       ],
       [
         'name' => 'won',
         'label' => 'Won (positive)',
-        'class' => 'Closed',
+        'class' => $closedCaseStatusClass,
       ],
       [
         'name' => 'lost',
         'label' => 'Lost (negative)',
-        'class' => 'Closed',
+        'class' => $closedCaseStatusClass,
       ],
     ];
 


### PR DESCRIPTION
## Overview
This PR adds groupings/statuses for the Prospect case statuses already defined in the prospect extension. 

The following Case statuses now have the Opened class:
- Enquiry (positive)
- Qualified (positive)
- In progress (positive)
- Submitted (positive)

And the following now have Closed class
- Won (positive)
- Lost (negative)

## After
- The initial upgrader used to add these statuses was modified to reflect this change. The change will be applied manually on the dev site since the upgrader has ran but the change has been tested to ensure it's working fine.
