### PR TITLE
RSE-267: Enable the Required components for CiviProspect extension

### DIFF
--- a/CRM/Prospect/Setup/EnableRequiredComponents.php
+++ b/CRM/Prospect/Setup/EnableRequiredComponents.php
@@ -21,10 +21,10 @@ class CRM_Prospect_Setup_EnableRequiredComponents {
       return;
     }
 
-    $enabledComponents = array_merge($enabledComponents, $componentsToEnable);
+    $componentsToEnable = array_merge($enabledComponents, $componentsToEnable);
 
     civicrm_api3('setting', 'create', [
-      'enable_components' => array_unique($enabledComponents),
+      'enable_components' => array_unique($componentsToEnable),
     ]);
   }
 

--- a/CRM/Prospect/Setup/EnableRequiredComponents.php
+++ b/CRM/Prospect/Setup/EnableRequiredComponents.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * CRM_Prospect_Setup_EnableRequiredComponents class.
+ */
+class CRM_Prospect_Setup_EnableRequiredComponents {
+
+  /**
+   * Enables the CiviContribute and CiviPledge Components.
+   */
+  public function apply() {
+    $getResult = civicrm_api3('setting', 'getsingle', [
+      'return' => ['enable_components'],
+    ]);
+
+    $enabledComponents = $getResult['enable_components'];
+    $componentsToEnable = ['CiviContribute', 'CiviPledge'];
+
+    // Check if these components are already enabled.
+    if (count(array_intersect($enabledComponents, $componentsToEnable)) == 2) {
+      return;
+    }
+
+    $enabledComponents = array_merge($enabledComponents, $componentsToEnable);
+
+    civicrm_api3('setting', 'create', [
+      'enable_components' => array_unique($enabledComponents),
+    ]);
+  }
+
+}

--- a/CRM/Prospect/Upgrader.php
+++ b/CRM/Prospect/Upgrader.php
@@ -7,6 +7,7 @@ use CRM_Prospect_Setup_CreateProspectWorkflowCaseStatuses as CreateProspectWorkf
 use CRM_Prospect_Setup_CreateProspectWorkflowCaseType as CreateProspectWorkflowCaseType;
 use CRM_Prospect_Setup_MoveCustomFieldsToProspecting as MoveCustomFieldsToProspecting;
 use CRM_Prospect_Setup_AddProspectCategoryCgExtendsValue as AddProspectCategoryCgExtendsValue;
+use CRM_Prospect_Setup_EnableRequiredComponents as EnableRequiredComponents;
 
 /**
  * Collection of upgrade steps.
@@ -56,6 +57,7 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
    */
   public function install() {
     $steps = [
+      new EnableRequiredComponents(),
       new CreateProspectingOptionValue(),
       new CreateProspectMenus(),
       new CreateProspectWorkflowCaseStatuses(),

--- a/CRM/Prospect/Upgrader/Steps/Step1005.php
+++ b/CRM/Prospect/Upgrader/Steps/Step1005.php
@@ -1,0 +1,23 @@
+<?php
+
+use CRM_Prospect_Setup_EnableRequiredComponents as EnableRequiredComponents;
+
+/**
+ * CRM_Prospect_Upgrader_Steps_Step1005 class.
+ */
+class CRM_Prospect_Upgrader_Steps_Step1005 {
+
+  /**
+   * Enables the CiviContribute and CiviPledge Components.
+   *
+   * @return bool
+   *   Return value in boolean.
+   */
+  public function apply() {
+    $step = new EnableRequiredComponents();
+    $step->apply();
+
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR enables the `Contribution` and `Pledge` Component for the CiviProspect extension. Without these components being enabled, the extension will not work as expected.

## Before
- The `Contribution` and `Pledge` Component were not enabled

## After
- An Upgrader was added to enable these components for sites already having this extension installed and a setup was also added to enable this components on extension installation.
