### PR TITLE
RSE-175: Fix Custom Fields Addition Logic

### DIFF
--- a/ang/prospect/prospect-converted/decorators/case-details.decorators.js
+++ b/ang/prospect/prospect-converted/decorators/case-details.decorators.js
@@ -53,6 +53,7 @@
               value: { display: paymentInfo.pledge_balance }
             });
           }
+
           if (paymentInfo.payment_completed) {
             addUpdateCustomField(financialInformationCustomField, 'payment_completed', {
               label: 'Payment completed',

--- a/ang/prospect/prospect-converted/decorators/case-details.decorators.js
+++ b/ang/prospect/prospect-converted/decorators/case-details.decorators.js
@@ -46,23 +46,39 @@
             return;
           }
 
-          var fieldToAdd = {};
-
-          if (paymentInfo.payment_entity === 'pledge') {
-            fieldToAdd = {
+          if (paymentInfo.pledge_balance) {
+            addUpdateCustomField(financialInformationCustomField, 'pledge_balance', {
               label: 'Pledge balance',
               name: 'pledge_balance',
               value: { display: paymentInfo.pledge_balance }
-            };
-          } else if (paymentInfo.payment_entity === 'contribute') {
-            fieldToAdd = {
+            });
+          }
+          if (paymentInfo.payment_completed) {
+            addUpdateCustomField(financialInformationCustomField, 'payment_completed', {
               label: 'Payment completed',
               name: 'payment_completed',
               value: { display: paymentInfo.payment_completed }
-            };
+            });
           }
+        }
 
-          financialInformationCustomField.fields = financialInformationCustomField.fields.concat(fieldToAdd);
+        /**
+         * Adds or Updates Custom fields
+         *
+         * @param {Object} financialInformationCustomField
+         * @param {String} fieldName
+         * @param {Object} fieldToAdd
+         */
+        function addUpdateCustomField (financialInformationCustomField, fieldName, fieldToAdd) {
+          var field = _.find(financialInformationCustomField.fields, function (customField) {
+            return customField.name === fieldName;
+          });
+
+          if (field) {
+            field.value = fieldToAdd.value;
+          } else {
+            financialInformationCustomField.fields = financialInformationCustomField.fields.concat(fieldToAdd);
+          }
         }
       };
     };


### PR DESCRIPTION
## Overview
Previously, the custom fields got added multiple times, if data was refreshed. This PR fixes that.

## Before
![before](https://user-images.githubusercontent.com/5058867/62755541-144b9500-ba92-11e9-82c1-21e7de917208.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/62755463-b61eb200-ba91-11e9-8336-de28c2922693.gif)

## Technical Details
1. In `case-details.decorators.js`, added logic, to check if the field already exists before adding it. If it already exists, it gets updated, otherwise it gets added.
```js
function addUpdateCustomField (financialInformationCustomField, fieldName, fieldToAdd) {
  var field = _.find(financialInformationCustomField.fields, function (customField) {
    return customField.name === fieldName;
  });

   if (field) {
    field.value = fieldToAdd.value;
  } else {
    financialInformationCustomField.fields = financialInformationCustomField.fields.concat(fieldToAdd);
  }
 }
```