### PR TITLE
RSE-216: Case Custom Fields UI Solution For Prospects

### DIFF
--- a/CRM/Prospect/Helper/CaseTypeCategory.php
+++ b/CRM/Prospect/Helper/CaseTypeCategory.php
@@ -47,4 +47,20 @@ class CRM_Prospect_Helper_CaseTypeCategory {
     return $results;
   }
 
+  /**
+   * Returns the case types for the prospect category.
+   *
+   * @return array
+   *   Array of Case Types indexed by Id.
+   */
+  public static function getProspectCaseTypes() {
+    $result = civicrm_api3('CaseType', 'get', [
+      'sequential' => 1,
+      'return' => ['title', 'id'],
+      'case_type_category' => self::PROSPECT_CASE_TYPE_CATEGORY_NAME,
+    ]);
+
+    return array_column($result['values'], 'title', 'id');
+  }
+
 }

--- a/CRM/Prospect/Setup/AddProspectCategoryCgExtendsValue.php
+++ b/CRM/Prospect/Setup/AddProspectCategoryCgExtendsValue.php
@@ -25,6 +25,7 @@ class CRM_Prospect_Setup_AddProspectCategoryCgExtendsValue {
       'name' => 'civicrm_case',
       'label' => $prospectCategoryLabel,
       'value' => 'prospecting',
+      'description' => 'CRM_Prospect_Helper_CaseTypeCategory::getProspectCaseTypes;',
       'is_active' => TRUE,
       'is_reserved' => TRUE,
     ]);


### PR DESCRIPTION
## Overview
We need a UI solution such that we can add a custom group that extends the Case Prospects category and we can select only case types belonging to this category. This PR solves that.


## Before
This does not exist.

## After
Since the Case Prospect has already been added to the custom group extends option values, It turns out that Civicrm uses the description field for the option value to determine which function to use to fetch the object subtypes. See [Here](https://github.com/civicrm/civicrm-core/blob/b2ccd9fe6cb84d96d35c85582418311509f9af9b/CRM/Core/BAO/CustomGroup.php#L2084-L2101). The solution here is to simply create a function that will return all case types related to the prospect category. This function is used on the Custom Group create and listing page.
<img width="1197" alt="New Custom Field Set  case-prospect 2019-08-14 16-14-21" src="https://user-images.githubusercontent.com/6951813/63032944-b6161c00-beae-11e9-974e-9825f466b770.png">
<img width="1293" alt="Custom Data  case-prospect 2019-08-14 16-14-38" src="https://user-images.githubusercontent.com/6951813/63032945-b6161c00-beae-11e9-802c-446a34a5fbdf.png">




