### PR TITLE
RSE-287: Fix Issue on Activities while changing Case Type on Prospects Category

### DIFF
--- a/CRM/Prospect/Setup/CreateProspectWorkflowCaseType.php
+++ b/CRM/Prospect/Setup/CreateProspectWorkflowCaseType.php
@@ -23,6 +23,7 @@ class CRM_Prospect_Setup_CreateProspectWorkflowCaseType {
       'statuses' => $this->getStatusDefinition(),
       'activityTypes' => $this->getActivityTypeDefinition(),
       'caseRoles' => $this->getCaseRolesDefinition(),
+      'activitySets' => $this->getActivitySets(),
     ];
 
     civicrm_api3('CaseType', 'create', [
@@ -88,6 +89,22 @@ class CRM_Prospect_Setup_CreateProspectWorkflowCaseType {
     ];
 
     return $caseRoles;
+  }
+
+  /**
+   * Returns the Timeline.
+   *
+   * @return array
+   *   The timeline.
+   */
+  private function getActivitySets() {
+    return [
+      [
+        'timeline' => TRUE,
+        'name' => 'standard_timeline',
+        'label' => 'Standard Timeline',
+      ],
+    ];
   }
 
 }


### PR DESCRIPTION
## Overview
The change case type functionality is broken when changing a case type for the Default Prospect workflow case type. The activities are messed up and gets duplicated. This PR fixes that.


## After
It turned out that the Default Prospect Workflow needed to have a timeline defined even if it contained no activities for the Change case functionality to work properly. This PR adds that

