### PR TITLE
RSE-271: Case Type Category Word Replacements

### DIFF
--- a/CRM/Prospect/Setup/AddProspectCategoryWordReplacement.php
+++ b/CRM/Prospect/Setup/AddProspectCategoryWordReplacement.php
@@ -1,0 +1,27 @@
+<?php
+
+use CRM_Prospect_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
+/**
+ * Class CRM_Prospect_Setup_AddProspectCategoryWordReplacement.
+ */
+class CRM_Prospect_Setup_AddProspectCategoryWordReplacement {
+
+  /**
+   * Creates the Prospecting word replacement option value.
+   */
+  public function apply() {
+    $optionName = CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME . "_word_replacement";
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'case_type_category_word_replacement_class',
+      'name' => $optionName,
+      'label' => $optionName,
+      'value' => 'CRM_Prospect_WordReplacement_ProspectCategory',
+      'is_default' => 1,
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+
+  }
+
+}

--- a/CRM/Prospect/Setup/AddProspectCategoryWordReplacement.php
+++ b/CRM/Prospect/Setup/AddProspectCategoryWordReplacement.php
@@ -11,6 +11,7 @@ class CRM_Prospect_Setup_AddProspectCategoryWordReplacement {
    * Creates the Prospecting word replacement option value.
    */
   public function apply() {
+    $this->ensureOptionGroupExists();
     $optionName = CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME . "_word_replacement";
     CRM_Core_BAO_OptionValue::ensureOptionValueExists([
       'option_group_id' => 'case_type_category_word_replacement_class',
@@ -20,6 +21,22 @@ class CRM_Prospect_Setup_AddProspectCategoryWordReplacement {
       'is_default' => 1,
       'is_active' => TRUE,
       'is_reserved' => TRUE,
+    ]);
+  }
+
+  /**
+   * This function ensures that the word replacement option group exists.
+   *
+   * On the development site, the prospect extension upgrader might run before
+   * the one in civicase and throw an error about the missing option group. This
+   * function takes care of that. Normally this will not occur for fresh install
+   * because civicase will be installed first and this option group will exist.
+   */
+  private function ensureOptionGroupExists() {
+    CRM_Core_BAO_OptionGroup::ensureOptionGroupExists([
+      'name' => 'case_type_category_word_replacement_class',
+      'title' => ts('Case Type Category Word Replacements'),
+      'is_reserved' => 1,
     ]);
 
   }

--- a/CRM/Prospect/Setup/CreateProspectMenus.php
+++ b/CRM/Prospect/Setup/CreateProspectMenus.php
@@ -65,7 +65,7 @@ class CRM_Prospect_Setup_CreateProspectMenus {
       [
         'label' => ts('Dashboard'),
         'name' => 'prospect_dashboard',
-        'url' => 'civicrm/case/a/#/case?case_type_category=prospecting',
+        'url' => 'civicrm/case/a/?case_type_category=prospecting#/case?case_type_category=prospecting',
         'permission' => 'access my cases and activities,access all cases and activities',
         'permission_operator' => 'OR',
       ],
@@ -79,7 +79,7 @@ class CRM_Prospect_Setup_CreateProspectMenus {
       [
         'label' => ts('Manage Prospects'),
         'name' => 'manage_prospect',
-        'url' => 'civicrm/case/a/#/case/list?cf=%7B"case_type_category":"prospecting"%7D',
+        'url' => 'civicrm/case/a/?case_type_category=prospecting#/case/list?cf=%7B"case_type_category":"prospecting"%7D',
         'permission' => 'access my cases and activities,access all cases and activities',
         'permission_operator' => 'OR',
       ],

--- a/CRM/Prospect/Setup/CreateProspectingOptionValue.php
+++ b/CRM/Prospect/Setup/CreateProspectingOptionValue.php
@@ -17,7 +17,7 @@ class CRM_Prospect_Setup_CreateProspectingOptionValue {
     CRM_Core_BAO_OptionValue::ensureOptionValueExists([
       'option_group_id' => 'case_type_categories',
       'name' => CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME,
-      'label' => CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME,
+      'label' => 'Prospects',
       'is_default' => 1,
       'is_active' => TRUE,
       'is_reserved' => TRUE,

--- a/CRM/Prospect/Upgrader.php
+++ b/CRM/Prospect/Upgrader.php
@@ -7,6 +7,7 @@ use CRM_Prospect_Setup_CreateProspectWorkflowCaseStatuses as CreateProspectWorkf
 use CRM_Prospect_Setup_CreateProspectWorkflowCaseType as CreateProspectWorkflowCaseType;
 use CRM_Prospect_Setup_MoveCustomFieldsToProspecting as MoveCustomFieldsToProspecting;
 use CRM_Prospect_Setup_AddProspectCategoryCgExtendsValue as AddProspectCategoryCgExtendsValue;
+use CRM_Prospect_Setup_AddProspectCategoryWordReplacement as AddProspectCategoryWordReplacement;
 use CRM_Prospect_Setup_EnableRequiredComponents as EnableRequiredComponents;
 
 /**
@@ -59,6 +60,7 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
     $steps = [
       new EnableRequiredComponents(),
       new CreateProspectingOptionValue(),
+      new AddProspectCategoryWordReplacement(),
       new CreateProspectMenus(),
       new CreateProspectWorkflowCaseStatuses(),
       new CreateProspectOwnerRelationship(),

--- a/CRM/Prospect/Upgrader/Steps/Step1006.php
+++ b/CRM/Prospect/Upgrader/Steps/Step1006.php
@@ -1,0 +1,23 @@
+<?php
+
+use CRM_Prospect_Setup_AddProspectCategoryWordReplacement as AddProspectCategoryWordReplacement;
+
+/**
+ * Class CRM_Prospect_Upgrader_Steps_Step1006.
+ */
+class CRM_Prospect_Upgrader_Steps_Step1006 {
+
+  /**
+   * Creates the Prospecting word replacement option value.
+   *
+   * @return bool
+   *   Return value in boolean.
+   */
+  public function apply() {
+    $step = new AddProspectCategoryWordReplacement();
+    $step->apply();
+
+    return TRUE;
+  }
+
+}

--- a/CRM/Prospect/WordReplacement/ProspectCategory.php
+++ b/CRM/Prospect/WordReplacement/ProspectCategory.php
@@ -1,0 +1,23 @@
+<?php
+
+use CRM_Prospect_ExtensionUtil as ExtensionUtil;
+
+/**
+ * Class ProspectCategory.
+ */
+class CRM_Prospect_WordReplacement_ProspectCategory implements CRM_Civicase_WordReplacement_BaseInterface {
+
+  /**
+   * {@inheritdoc}
+   *
+   * @return array
+   *   Returns the word replacements
+   */
+  public function get() {
+    $configFile = CRM_Core_Resources::singleton()
+      ->getPath(ExtensionUtil::LONG_NAME, 'config/word_replacement/prospect_category.php');
+
+    return include $configFile;
+  }
+
+}

--- a/config/word_replacement/prospect_category.php
+++ b/config/word_replacement/prospect_category.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Returns the words to be replaced and the replacement words.
+ */
+
+return [
+  'Case' => 'Prospect',
+  'Cases' => 'Prospects',
+  'case' => 'prospect',
+  'cases' => 'prospects',
+];


### PR DESCRIPTION
## Overview
Sequel to https://github.com/compucorp/uk.co.compucorp.civicase/pull/238, This PR allows the Prospect extension provides the array of words to be replaced and replacement words to be used on the Prospect case category type pages.

## Before
Word replacements was functionality not available
<img width="1280" alt="Open Case  case-prospect 2019-08-30 11-23-38" src="https://user-images.githubusercontent.com/6951813/64013929-d08bfe80-cb18-11e9-8e10-2e0b7f3833f3.png">
<img width="1280" alt="Manage Cases  case-prospect 2019-08-30 11-24-22" src="https://user-images.githubusercontent.com/6951813/64013949-e00b4780-cb18-11e9-8ef1-655e4751bdbc.png">
<img width="1280" alt="CiviCase Dashboard - All Cases  case-prospect 2019-08-30 11-23-59" src="https://user-images.githubusercontent.com/6951813/64013962-e8fc1900-cb18-11e9-9fbd-03a6e58d122a.png">


## After
<img width="1279" alt="Open Prospect | case-prospect 2019-08-30 11-14-37" src="https://user-images.githubusercontent.com/6951813/64013750-6ffcc180-cb18-11e9-8806-cb06a2be3da3.png">

<img width="1280" alt="Manage Cases  case-prospect 2019-08-30 11-21-53" src="https://user-images.githubusercontent.com/6951813/64013773-7d19b080-cb18-11e9-811a-7716cafa968c.png">
<img width="1291" alt="CiviProspect Dashboard - All Prospects  case-prospect 2019-08-30 11-18-51" src="https://user-images.githubusercontent.com/6951813/64013774-7db24700-cb18-11e9-86fd-c3755a7d0fdc.png">


## Technical Details
The Prospect extension defines a `CRM_Prospect_WordReplacement_ProspectCategory` class that implements the `CRM_Civicase_WordReplacement_BaseInterface` and provides a method that returns the word replacements array. 

```php
return [
  'Case' => 'Prospect',
  'Cases' => 'Prospects',
  'case' => 'prospect',
  'cases' => 'prospects',
];
```

This `CRM_Prospect_WordReplacement_ProspectCategory` is added via an option value to the `case_type_category_word_replacement_class` option group so that Civicase knows the class to call for word replacements for prospect category related pages.

