### PR TITLE
RSE-373: Remove "Positive" and "Negative" from Default Prospect Status Labels

### DIFF
--- a/CRM/Prospect/Setup/CreateProspectWorkflowCaseStatuses.php
+++ b/CRM/Prospect/Setup/CreateProspectWorkflowCaseStatuses.php
@@ -36,32 +36,32 @@ class CRM_Prospect_Setup_CreateProspectWorkflowCaseStatuses {
     $caseStatuses = [
       [
         'name' => 'enquiry',
-        'label' => 'Enquiry (positive)',
+        'label' => 'Enquiry',
         'class' => $openCaseStatusClass,
       ],
       [
         'name' => 'qualified',
-        'label' => 'Qualified (positive)',
+        'label' => 'Qualified',
         'class' => $openCaseStatusClass,
       ],
       [
         'name' => 'in_progress',
-        'label' => 'In progress (positive)',
+        'label' => 'In progress',
         'class' => $openCaseStatusClass,
       ],
       [
         'name' => 'submitted',
-        'label' => 'Submitted (positive)',
+        'label' => 'Submitted',
         'class' => $openCaseStatusClass,
       ],
       [
         'name' => 'won',
-        'label' => 'Won (positive)',
+        'label' => 'Won',
         'class' => $closedCaseStatusClass,
       ],
       [
         'name' => 'lost',
-        'label' => 'Lost (negative)',
+        'label' => 'Lost',
         'class' => $closedCaseStatusClass,
       ],
     ];


### PR DESCRIPTION
## Overview
This PR removes the `positive` and `negative` from the default prospect status labels. 
The labels was modified in the setup and no upgrader was added for this change since this has not been released yet.

## Before
- The labels contains the word `positive` or `negative`

## After
- The labels no longer contains the word `positive` or `negative`


