### PR TITLE
RSE-347: Use global functions

### DIFF
--- a/ang/prospect.ang.php
+++ b/ang/prospect.ang.php
@@ -8,13 +8,15 @@
  * http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules.
  */
 
+use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
+
 /**
  * Get a list of JS files.
  */
 function get_prospect_js_files() {
   return array_merge([
     'ang/prospect.js',
-  ], glob_recursive(dirname(__FILE__) . '/prospect/*.js'));
+  ], GlobRecursive::get(dirname(__FILE__) . '/prospect/*.js'));
 }
 
 return [

--- a/ang/prospect/prospect-converted/services/prospect-converted.service.js
+++ b/ang/prospect/prospect-converted/services/prospect-converted.service.js
@@ -8,8 +8,9 @@
    *
    * @param {object} crmApi crm api
    * @param {*} ProspectGlobalValues prospect global values
+   * @param CaseTypeCategory
    */
-  function ProspectConverted (crmApi, ProspectGlobalValues) {
+  function ProspectConverted (crmApi, ProspectGlobalValues, CaseTypeCategory) {
     /**
      * Returns if the case is converted to Prospect
      *
@@ -44,7 +45,7 @@
      * @returns {boolean} if prospect type category
      */
     this.checkIfProspectingCaseTypeCategory = function (caseData) {
-      var caseTypeCategory = CRM.civicase.caseTypeCategories[caseData['case_type_id.case_type_category']].name;
+      var caseTypeCategory = CaseTypeCategory.getAll()[caseData['case_type_id.case_type_category']].name;
 
       return caseTypeCategory === ProspectGlobalValues.caseTypeCategory;
     };

--- a/prospect.civix.php
+++ b/prospect.civix.php
@@ -338,7 +338,6 @@ function _prospect_civix_civicrm_caseTypes(&$caseTypes) {
  */
 function _prospect_civix_civicrm_angularModules(&$angularModules) {
   _prospect_includeAngularModules($angularModules);
-  _prospect_addProspectAsRequirementForCivicase($angularModules);
 }
 
 /**
@@ -363,25 +362,6 @@ function _prospect_includeAngularModules(array &$angularModules) {
       $module['ext'] = E::LONG_NAME;
     }
     $angularModules[$name] = $module;
-  }
-}
-
-/**
- * Add Prospect as a requirement of civicase.
- *
- * @param array $angularModules
- *   Angular Modules.
- */
-function _prospect_addProspectAsRequirementForCivicase(array &$angularModules) {
-  if (isset($angularModules['civicase'])) {
-    $angularModules['civicase']['requires'][] = 'prospect';
-  }
-  else {
-    CRM_Core_Session::setStatus(
-      'The <strong>Prospect</strong> extension requires <strong>CiviCase</strong> to be installed first.',
-      'Warning',
-      'no-popup'
-    );
   }
 }
 

--- a/prospect.php
+++ b/prospect.php
@@ -128,6 +128,13 @@ function prospect_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 }
 
 /**
+ * Implements addCiviCaseDependentAngularModules().
+ */
+function prospect_addCiviCaseDependentAngularModules(&$dependentModules) {
+  $dependentModules[] = "prospect";
+}
+
+/**
  * Implements hook_civicrm_entityTypes().
  */
 function prospect_civicrm_entityTypes(&$entityTypes) {


### PR DESCRIPTION
## Overview
As part of this PR, the global functions defined in Civicase are used.
Related PR:
https://github.com/compucorp/uk.co.compucorp.civicase/pull/284
https://github.com/compucorp/uk.co.compucorp.civiawards/pull/13

## Technical Details
1. Using `GlobRecursive` global class from Civicase.
2. Using `addCiviCaseDependentAngularModules` hook to inject `prospect` as a dependency of civicase.
3. Using `CaseTypeCategory` service.