### PR TITLE
RSE-510: Fix Civicrm Error Screen When Logging In and on APIV4 Page

### DIFF
--- a/CRM/Prospect/Hook/APIWrappers/CaseCreationAPIWrapper.php
+++ b/CRM/Prospect/Hook/APIWrappers/CaseCreationAPIWrapper.php
@@ -12,10 +12,14 @@ class CRM_Prospect_Hook_APIWrappers_CaseCreationAPIWrapper {
    *
    * @param array $wrappers
    *   Wrappers.
-   * @param array $apiRequest
+   * @param mixed $apiRequest
    *   Api Request.
    */
-  public function run(array &$wrappers, array $apiRequest) {
+  public function run(array &$wrappers, $apiRequest) {
+    if (is_object($apiRequest)) {
+      return;
+    }
+
     if (!$this->shouldRun($apiRequest)) {
       return;
     }


### PR DESCRIPTION
## Overview
Logging in as Civicrm admin and clicking on Civicrm main menu results in an error page. This error page is also observed when visiting the API V4 explorer page.

<img width="1280" alt="Error  CiviCase 2019-11-05 18-09-15" src="https://user-images.githubusercontent.com/6951813/68229404-84b57400-fff7-11e9-960b-546363c86344.png">


## Before
The error page described above is observed on API V4 page and when the Civicrm admin logs in.

## After
Issue is fixed and the error page is no longer observed.
<img width="1280" alt="CiviCRM API v4  CiviCase 2019-11-05 18-11-43" src="https://user-images.githubusercontent.com/6951813/68229568-cd6d2d00-fff7-11e9-98ef-dc6a737cbd31.png">


## Technical Details
This issue is observed on sites running Civicrm 5.19.  Recently in version 5.19, the APIV4 has become a part of civicrm core. As such, APIv4 calls are invoked on some pages in addition to APIv3 calls.
The API wrapper hook `hook_civicrm_apiWrappers(&$wrappers, $apiRequest)` accepts two parameters, the $apiRequest parameter for API V4 is no longer an array as is the case for V3 but is now an object.
This is causing an issue in the hook implementation for the prospect extension as the function was expecting an array.

<img width="1277" alt="site  VagrantProjectscase-compuclientsite  -  profilescompuclientcivicrm_extensionsuk co compucorp civicrm prospectp… 2019-11-05 14-13-09" src="https://user-images.githubusercontent.com/6951813/68229990-8895c600-fff8-11e9-984d-f3b9cfc9176b.png">


A quick return after a check to see if the $apiRequest parameter is an object fixes the issue.

```php
    if (is_object($apiRequest)) {
      return;
    }
```
