### PR TITLE
CPS-25: Fix error on cg page after disabling extension

### DIFF
--- a/CRM/Prospect/Setup/AddProspectCategoryCgExtendsValue.php
+++ b/CRM/Prospect/Setup/AddProspectCategoryCgExtendsValue.php
@@ -5,29 +5,60 @@
  */
 class CRM_Prospect_Setup_AddProspectCategoryCgExtendsValue {
 
+  const PROSPECTS_CATEGORY_LABEL = 'Case (Prospects)';
+
   /**
    * Add Prospecting as a valid Entity that a custom group can extend.
    */
   public function apply() {
-    $prospectCategoryLabel = 'Case (Prospects)';
-
     $result = civicrm_api3('OptionValue', 'get', [
       'option_group_id' => 'cg_extend_objects',
-      'label' => $prospectCategoryLabel,
+      'label' => self::PROSPECTS_CATEGORY_LABEL,
     ]);
 
     if ($result['count'] > 0) {
+      $this->toggleOptionValueStatus(TRUE);
+
       return;
     }
 
     civicrm_api3('OptionValue', 'create', [
       'option_group_id' => 'cg_extend_objects',
       'name' => 'civicrm_case',
-      'label' => $prospectCategoryLabel,
+      'label' => self::PROSPECTS_CATEGORY_LABEL,
       'value' => 'prospecting',
       'description' => 'CRM_Prospect_Helper_CaseTypeCategory::getProspectCaseTypes;',
       'is_active' => TRUE,
       'is_reserved' => TRUE,
+    ]);
+  }
+
+  /**
+   * Enables/Disables Prospects option values.
+   *
+   * The method also updates the Option Value 'description' to empty when the
+   * extension is disabled. Because the 'description' is dynamically loaded,
+   * this helps prevent the fatal error that is thrown when Civi tries
+   * to load a class from a disabled extension.
+   *
+   * @param bool $newStatus
+   *   True to enable, False to disable.
+   */
+  public function toggleOptionValueStatus($newStatus) {
+    $optionValueDescription = (
+      $newStatus ?
+        'CRM_Prospect_Helper_CaseTypeCategory::getProspectCaseTypes;' :
+          ''
+    );
+
+    civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'cg_extend_objects',
+      'label' => self::PROSPECTS_CATEGORY_LABEL,
+      'api.OptionValue.create' => [
+        'id' => '$value.id',
+        'description' => $optionValueDescription,
+        'is_active' => $newStatus,
+      ],
     ]);
   }
 

--- a/CRM/Prospect/Upgrader.php
+++ b/CRM/Prospect/Upgrader.php
@@ -44,6 +44,9 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
    */
   public function enable() {
     $this->toggleDefaulValues(1);
+
+    $prospectCategoryCgExtendsValue = new AddProspectCategoryCgExtendsValue();
+    $prospectCategoryCgExtendsValue->toggleOptionValueStatus(TRUE);
   }
 
   /**
@@ -51,6 +54,9 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
    */
   public function disable() {
     $this->toggleDefaulValues(0);
+
+    $prospectCategoryCgExtendsValue = new AddProspectCategoryCgExtendsValue();
+    $prospectCategoryCgExtendsValue->toggleOptionValueStatus(FALSE);
   }
 
   /**


### PR DESCRIPTION
## Overview
When the extension is disabled and you try to access the url `/civicrm/admin/custom/group?reset=1`, an error is displayed as shown in the screenshot below. This PR fixes that. 

## Before
![CPS-25-before-2](https://raw.githubusercontent.com/16kilobyte/screenshots/master/CPS-25-before-2.png)

## After
![CPS-25-after-2](https://raw.githubusercontent.com/16kilobyte/screenshots/master/CPS-25-after-2.png)

## Technical Details
The fatal error is caused by the line `'description' => 'CRM_Prospect_Helper_CaseTypeCategory::getProspectCaseTypes;'` in https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/blob/13ed01183c840bf7ff065a520fe86e02c50f21c8/CRM/Prospect/Setup/AddProspectCategoryCgExtendsValue.php#L28. When the module is disabled, the module files are not loaded again and when Civi tries to resolve the class  `CRM_Prospect_Helper_CaseTypeCategory::getProspectCaseTypes` to get the description of the Option value and fails to find the class (because it is not loaded), it throws the fatal error.

## Comments
When the extension is disabled, we remove the description and re-add it back when the extension is re-enabled