### PR TITLE
RSE-767: Fix Class Not Found Error When Prospect Is Enabled

### DIFF
--- a/prospect.php
+++ b/prospect.php
@@ -181,13 +181,16 @@ function _prospect_civicrm_get_custom_group_id($customGroupName) {
  */
 function prospect_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   $hooks = [
-    new CRM_Prospect_Hook_Post_UpdateProspectFields(),
-    new CRM_Prospect_Hook_Post_ConvertContributionToProspect(),
-    new CRM_Prospect_Hook_Post_ConvertPledgeToProspect(),
+    'CRM_Prospect_Hook_Post_UpdateProspectFields',
+    'CRM_Prospect_Hook_Post_ConvertContributionToProspect',
+    'CRM_Prospect_Hook_Post_ConvertPledgeToProspect',
   ];
 
-  foreach ($hooks as $hook) {
-    $hook->run($op, $objectName, $objectId, $objectRef);
+  foreach ($hooks as $hookClass) {
+    if (class_exists($hookClass)) {
+      $hook = new $hookClass();
+      $hook->run($op, $objectName, $objectId, $objectRef);
+    }
   }
 }
 

--- a/prospect.php
+++ b/prospect.php
@@ -195,22 +195,9 @@ function prospect_civicrm_post($op, $objectName, $objectId, &$objectRef) {
  * Implements hook_civicrm_apiWrappers().
  */
 function prospect_civicrm_apiWrappers(&$wrappers, $apiRequest) {
-  // hook_civicrm_config is responsible for including an extension path to
-  // autoload files for that extension.
-  // Since Prospect extension implements the hook_civicrm_fieldOptions
-  // it calls an API internally to fetch Campaign_Id Custom field,
-  // This causes the API wrapper hook to be invoked prematurely.
-  // Hence the below condition is required to avoid `Class Not Found` error.
-  if ($apiRequest['entity'] === 'CustomField') {
-    return;
-  }
-
-  $hooks = [
-    new CRM_Prospect_Hook_APIWrappers_CaseCreationAPIWrapper(),
-  ];
-
-  foreach ($hooks as $hook) {
-    $hook->run($wrappers, $apiRequest);
+  if ($apiRequest == 'Case') {
+    $caseCreationApiWrapper = new CRM_Prospect_Hook_APIWrappers_CaseCreationAPIWrapper();
+    $caseCreationApiWrapper->run($wrappers, $apiRequest);
   }
 }
 


### PR DESCRIPTION
## Overview
When creating a site with compuclient and prospect is set to be enabled by default via an upgrader, the civicrm pages becomes inaccessible with an error screen with the message: `The website encountered an unexpected error. Please try again later.`

## Before
- When prospect is enabled on a site created with compuclient profile, the civicrm pages become inaccessible.

The error gotten is `Error: Class 'CRM_Prospect_Hook_APIWrappers_CaseCreationAPIWrapper' not found in prospect_civicrm_apiWrappers() (line 209 of /var/www/prospect/profiles/compuclient/modules/contrib/civicrm/ext/uk.co.compucorp.civicrm.prospect/prospect.php).` 

Another error was gotten after the above was fixed:
`Error: Class 'CRM_Prospect_Hook_Post_UpdateProspectFields'       [error]
not found in prospect_civicrm_post() (line 184 of
/var/www/compuclient-rse-767-x1s.compubox.co.uk/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/uk.co.compucorp.civicrm.prospect/prospect.php`

## After
To fix these issues: 
- The `CRM_Prospect_Hook_APIWrappers_CaseCreationAPIWrapper` class is only added when the Entity is Case. At this point we are sure that the files needed to make the class found would have been included.
- The hooks for the ` prospect_civicrm_post` are only invoked if these classes exist.


## Technical Details
 The `org.civicoop.groupprotect` extension was recently added to the list of extensions downloaded and enabled in the compuclient profile by default.

The `hook_civicrm_config` for each extension  is responsible for loading files required by an extension and it is invoked for all extensions one after the other.
This `org.civicoop.groupprotect` extension makes an [API call](https://github.com/CiviCooP/org.civicoop.groupprotect/blob/master/groupprotect.php#L83)([Here](https://github.com/CiviCooP/org.civicoop.groupprotect/blob/master/CRM/Groupprotect/Config.php#L61)) in it's implementation of the `hook_civicrm_config` right before the `hook_civicrm_config` of the prospect extension is invoked. 
Since the API call will invoke the `hook_civicrm_apiWrappers` hook, this leads to a not found Class error for the `CRM_Prospect_Hook_APIWrappers_CaseCreationAPIWrapper` class when the extension's API wrapper hook is invoked.

Also the API call in the `org.civicoop.groupprotect` extension will invoke the ` hook_civicrm_post` for all extensions after the `group_protect` Custom group has been created. At this point, the files needed for the prospect extension has not yet been included and this causes an error of Class not found when `prospect_civicrm_post` is called.

The `hook_civicrm_config` is called alphabetically for extensions, these issues are not observed for the Awards and Cases extension because the files needed for these extensions have already been included before the `groupprotect` extension's `hook_civicrm_config`  is called. However `groupprotect` extension's `hook_civicrm_config`  is called is called before `prospect` extension's implementation (g comes before p). 

What is implemented in `groupprotect's ` `hook_civicrm_config` should rather have been implemented in a place like the install hook rather than in the config hook except there is an obvious reason for doing that.
Issues like these may still happen where we have an extension having some implementation in the `hook_civicrm_config` that results in a Class not found error in other extensions. This might require us updating our implementation of hook classes to check if they are present before being invoked.
