### PR TITLE
RSE-761: Fix Issues With Saving Prospect Custom Field Values Not Saving

### DIFF
--- a/CRM/Prospect/Setup/AddProspectCategoryCgExtendsValue.php
+++ b/CRM/Prospect/Setup/AddProspectCategoryCgExtendsValue.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_Prospect_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 /**
  * CRM_Prospect_Setup_AddProspectCategoryCgExtendsValue class.
  */
@@ -26,7 +27,7 @@ class CRM_Prospect_Setup_AddProspectCategoryCgExtendsValue {
       'option_group_id' => 'cg_extend_objects',
       'name' => 'civicrm_case',
       'label' => self::PROSPECTS_CATEGORY_LABEL,
-      'value' => 'prospecting',
+      'value' => CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME,
       'description' => 'CRM_Prospect_Helper_CaseTypeCategory::getProspectCaseTypes;',
       'is_active' => TRUE,
       'is_reserved' => TRUE,

--- a/CRM/Prospect/Setup/MoveCustomFieldsToProspecting.php
+++ b/CRM/Prospect/Setup/MoveCustomFieldsToProspecting.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Prospect_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
 /**
  * Moves prospect custom fields to prospect category type..
  */
@@ -27,7 +29,7 @@ class CRM_Prospect_Setup_MoveCustomFieldsToProspecting {
     foreach ($result['values'] as $value) {
       civicrm_api3('CustomGroup', 'create', [
         'id' => $value['id'],
-        'extends' => 'prospecting',
+        'extends' => CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME,
       ]);
     }
   }


### PR DESCRIPTION
## Overview
Please refer to https://github.com/compucorp/uk.co.compucorp.civicase/pull/354 for more details about the issue.

## Before
- The prospect custom field values does not save under some certain conditions as described in the linked PR. 

## After
The Prospect option value name constant is used where necessary instead of hardcoding the value which was causing issues before where the values is in sentence case in some places and lowercase in other places.
