### PR TITLE
RSE-762: Add API Permission For Fetching Converted Prospect

### DIFF
--- a/prospect.php
+++ b/prospect.php
@@ -8,6 +8,15 @@
 require_once 'prospect.civix.php';
 
 /**
+ * Implements hook_civicrm_alterAPIPermissions().
+ *
+ * @link https://docs.civicrm.org/dev/en/master/hooks/hook_civicrm_alterAPIPermissions/
+ */
+function prospect_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
+  $permissions['prospect_converted']['get'] = ['access CiviCRM'];
+}
+
+/**
  * Implements hook_civicrm_config().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config


### PR DESCRIPTION
## Overview
A user without the `administer Civicrm` permission cannot see the values for a prospect converted to a pledge or contribution. This PR fixes the issue and sets the Access CiviCRM backend and API permission as the required permission to access the API for fetching this information. 

## Before
There was no API permission set for the ProspectConverted.get API so it uses the default `administer Civicrm` permission  set by Civi.
<img width="1280" alt="Manage Cases  CiviAwards 2020-02-11 11-24-08" src="https://user-images.githubusercontent.com/6951813/74228626-1f8db080-4cc1-11ea-9e16-04a2843ec48b.png">


## After
The ProspectConverted.get API so now uses the Access CiviCRM backend and API permission as the required permission to access the API for fetching this information.

<img width="1279" alt="Manage Cases  CiviAwards 2020-02-11 11-11-56" src="https://user-images.githubusercontent.com/6951813/74227793-81e5b180-4cbf-11ea-8133-0c6046cfd326.png">
 

## Comments
This permission will suffice for now but when the work for case category permission is merged to the master branch for cases, the permission will be updated to use the same case category permission required for accessing a prospect.
