### PR TITLE
RSE-763: Fix Warning About Activity Being Suspicious when Converting to Pledge or Contribution

### DIFF
--- a/CRM/Prospect/Setup/CreateProspectMenus.php
+++ b/CRM/Prospect/Setup/CreateProspectMenus.php
@@ -40,7 +40,7 @@ class CRM_Prospect_Setup_CreateProspectMenus {
       'url' => NULL,
       'permission_operator' => 'OR',
       'is_active' => 1,
-      'permission' => 'access my cases and activities,access all cases and activities',
+      'permission' => 'access my prospecting and activities,access all prospecting and activities',
       'icon' => 'crm-i fa-folder-open-o',
     ];
 
@@ -66,21 +66,21 @@ class CRM_Prospect_Setup_CreateProspectMenus {
         'label' => ts('Dashboard'),
         'name' => 'prospect_dashboard',
         'url' => 'civicrm/case/a/?case_type_category=prospecting#/case?case_type_category=prospecting',
-        'permission' => 'access my cases and activities,access all cases and activities',
+        'permission' => 'access my prospecting and activities,access all prospecting and activities',
         'permission_operator' => 'OR',
       ],
       [
         'label' => ts('New Prospect'),
         'name' => 'new_prospect',
         'url' => 'civicrm/case/add?case_type_category=prospecting&action=add&reset=1&context=standalone',
-        'permission' => 'add cases,access all cases and activities',
+        'permission' => 'add prospecting,access all prospecting and activities',
         'permission_operator' => 'OR',
       ],
       [
         'label' => ts('Manage Prospects'),
         'name' => 'manage_prospect',
         'url' => 'civicrm/case/a/?case_type_category=prospecting#/case/list?cf=%7B"case_type_category":"prospecting"%7D',
-        'permission' => 'access my cases and activities,access all cases and activities',
+        'permission' => 'access my prospecting and activities,access all prospecting and activities',
         'permission_operator' => 'OR',
       ],
     ];

--- a/prospect.php
+++ b/prospect.php
@@ -35,6 +35,16 @@ function prospect_civicrm_xmlMenu(&$files) {
 }
 
 /**
+ * Implements hook_civicrm_alterMenu().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterMenu
+ */
+function prospect_civicrm_alterMenu(&$items) {
+  $items['civicrm/contact/view/pledge']['ids_arguments']['json'][] = 'civicase_reload';
+  $items['civicrm/contact/view/contribution']['ids_arguments']['json'][] = 'civicase_reload';
+}
+
+/**
  * Implements hook_civicrm_install().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install


### PR DESCRIPTION
## Overview
This PR fixes a warning about activity being suspicious when trying to convert a prospect to a pledge or contribution. The warning is not there when the user is assigned the `CiviCRM: skip IDS check` permission but these permission is not what we intent to give to a prospect user.

## Before
The issue described above exists
![ConvertBefore](https://user-images.githubusercontent.com/6951813/82808630-3fb53a00-9e82-11ea-807e-0a9d826315ad.gif)


## After
- The Civicase reload parameter passed when converting to pledge or contribution causes civicrm to flag the activity as suspicious. The fix was to use the alterMenu hook to set the parameter to be interpreted as Json for the view pledge and view contribution pages. When this is done, the URL is not flagged as suspicious again.

![Convert](https://user-images.githubusercontent.com/6951813/82808648-49d73880-9e82-11ea-9756-f8074dce4a04.gif)


- The Prospect menu permissions was also updated to the proper case category permission because initially, the permissions used were the cases permission.