### PR TITLE
RSE-1121: Release v2.0.0-beta.1

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -15,8 +15,8 @@
     <url desc="Support">https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/blob/master/readme.md</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2019-03-26</releaseDate>
-  <version>2.0</version>
+  <releaseDate>2020-06-04</releaseDate>
+  <version>2.0.0-beta.1</version>
   <develStage></develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
## Release Update - 04th June, 2020

**New Features**
- Made CiviProspect compatible to new version of [Civicase](https://github.com/compucorp/uk.co.compucorp.civicase)

