### PR TITLE
ACU-103: Fix Issue With Installing Prospects On Some Sites

### DIFF
--- a/CRM/Prospect/Upgrader.php
+++ b/CRM/Prospect/Upgrader.php
@@ -51,8 +51,8 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
       new CreateProspectMenus(),
       new CreateProspectWorkflowCaseStatuses(),
       new CreateProspectOwnerRelationship(),
-      new CreateProspectWorkflowCaseType(),
       new ProcessProspectCategoryForCustomGroupSupport(),
+      new CreateProspectWorkflowCaseType(),
       new MoveCustomFieldsToWorkFlowCaseType(),
     ];
 


### PR DESCRIPTION

## Overview
When installing prospect on some sites (not all), the upgrader to install the extension fails with an error and prospect is not installed.

## Before
- The issue described above exists.

## After
- Issue described is resolved.

## Technical Details
An error occurs when installing prospect on a site with the latest version of civicase installed.

```php
6' is not a valid option for field extends_entity_column_id 
```

It turned out that a hook running in civicase on creation of a Case type was expecting a value that has not yet been created in Civiprospect. The code [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Hook/Post/UpdateCaseTypeListForCaseCategoryCustomGroup.php#L65 ) throws an error because the prospect case category option has not yet been registered as part of the `custom_data_type` option group.

This issue is fixed by simply re-ordering the steps in the Upgrader.php file and moving this [line](https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/blob/master/CRM/Prospect/Upgrader.php#L55) to be before the `CreateProspectWorkflowCaseType` call so that the Prospect category has been enabled for custom group support before the Prospect case type is created.