### PR TITLE
CPS-248: Release v2.0.0-beta.2

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -15,8 +15,8 @@
     <url desc="Support">https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/blob/master/readme.md</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-06-04</releaseDate>
-  <version>2.0.0-beta.1</version>
+  <releaseDate>2020-06-18</releaseDate>
+  <version>2.0.0-beta.2</version>
   <develStage></develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
## Release Update - 18th June, 2020

**Bug Fixes**
- Fixed a bug, when installing prospect on some sites, the upgrader to install the extension fails with an error and prospect is not installed.

**Updates for Developers**
- Added Github Action to run Javascript, CSS, PHP linters.
