### PR TITLE
RSE-1225: Fix blank Case Category Field For Workflow Case Type on Installation 

### DIFF
--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -11,5 +11,7 @@
     <!--Drupal expects function names like civicase_civicrm_pre_process but civi can have-->
     <!--civicase_civicrm_preProcess which is valid for civi.-->
     <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
+    <!-- this was was added in drupal, but in civicrm we ignore this rule -->
+    <exclude name="Drupal.Classes.UseGlobalClass.RedundantUseStatement"/>
   </rule>
 </ruleset>


### PR DESCRIPTION
## Overview
When Prospect extension and CiviCase are installed together for the first time on a site, The Default Prospect workflow case type that ships with the prospect extension is created without being attached to a Case category in the Case Type table.

## Before
The issue above exists.

## After
This issue is because the `case_type_category` field is a field that is added via a hook and is not part of the Core Case Type DAO file and so on fresh installation, this field is not available via the Case Type API. This issue was observed also in CiviCase and that is why an SQL query is used to update case type categories [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Setup/MoveCaseTypesToCasesCategory.php#L42-L50) rather than the API.
The fix was to update the Case type category using an SQL query


## Comment
A PHP lint error was also fixed. See more details [here](https://github.com/compucorp/uk.co.compucorp.civicase/pull/483)