### PR TITLE
CPS-349: Assign Default Prospect Workflow Case Type To Prospect

### DIFF
--- a/CRM/Prospect/Setup/CreateProspectWorkflowCaseType.php
+++ b/CRM/Prospect/Setup/CreateProspectWorkflowCaseType.php
@@ -26,7 +26,7 @@ class CRM_Prospect_Setup_CreateProspectWorkflowCaseType {
       'activitySets' => $this->getActivitySets(),
     ];
 
-    civicrm_api3('CaseType', 'create', [
+    $result = civicrm_api3('CaseType', 'create', [
       'name' => 'default_prospect_workflow',
       'title' => 'Default Prospect Workflow',
       'description' => "The Default Prospect Workflow Case Type",
@@ -34,6 +34,46 @@ class CRM_Prospect_Setup_CreateProspectWorkflowCaseType {
       'is_active' => 0,
       'case_type_category' => 'Prospecting',
     ]);
+    // Updating through manual query is unavoidable here
+    // as case_type_category is not a core field and it does
+    // not gets filled through api during installation.
+    $this->updateCaseTypeCategoryToProspecting($result['id']);
+  }
+
+  /**
+   * Updates the case type category to "Prospecting".
+   *
+   * @param int $caseTypeId
+   *   Case Type Id.
+   */
+  private function updateCaseTypeCategoryToProspecting($caseTypeId) {
+    $caseTypeTable = CRM_Case_BAO_CaseType::getTableName();
+    $caseCategoryOptionValue = $this->getCaseCategoryOptionValueForProspecting();
+    CRM_Core_DAO::executeQuery(
+      "UPDATE {$caseTypeTable} SET case_type_category = %1 WHERE id = $caseTypeId",
+      [1 => [$caseCategoryOptionValue, 'Integer']]
+    );
+  }
+
+  /**
+   * Returns the Case category option value.
+   *
+   * @return int|null
+   *   Case category value.
+   */
+  private function getCaseCategoryOptionValueForProspecting() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => 'case_type_categories',
+      'name' => CRM_Prospect_Helper_CaseTypeCategory::PROSPECT_CASE_TYPE_CATEGORY_NAME,
+      'return' => ['value'],
+    ]);
+
+    if ($result['count'] == 0) {
+      return;
+    }
+
+    return $result['values'][0]['value'];
   }
 
   /**

--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -9,6 +9,6 @@ fi
 chmod +x phpcs.phar
 
 # Clone Drupal Coder repo
-if [ ! -d drupal/coder ]; then
-  git clone --depth 1 https://git.drupalcode.org/project/coder.git drupal/coder
+if [ ! -d civicrm/coder ]; then
+  git clone --depth 1 https://github.com/civicrm/coder.git civicrm/coder
 fi

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="PHP Custom Ruleset">
-  <description>Drupal Coder Ruleset with some exclusions</description>
-  <rule ref="bin/drupal/coder/coder_sniffer/Drupal">
-    <!-- CiviCRM expects to have file names with underscores -->
-    <!-- Example: The Class `CRM_Civicase_Upgrader` has a file name of `Upgrader.php` -->
-    <!-- Hence the following rules are excluded -->
-    <exclude name="Drupal.NamingConventions.ValidClassName.NoUnderscores"/>
-    <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
-    <exclude name="Drupal.Classes.ClassFileName.NoMatch"/>
-    <!--Drupal expects function names like civicase_civicrm_pre_process but civi can have-->
-    <!--civicase_civicrm_preProcess which is valid for civi.-->
-    <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
+  <description>Civicrm Coder Ruleset</description>
+  <rule ref="bin/civicrm/coder/coder_sniffer/Drupal">
   </rule>
 </ruleset>


### PR DESCRIPTION
## Overview
This pr assigns the default prospect workflow case type to Prospecting category on Prospect extension installation. This PR also changes the coder type from drupal to civicrm.

## Before
The default prospect workflow was not assigned to any category.

## Technical Details
`CRM/Prospect/Setup/CreateProspectWorkflowCaseType.php`  is responsible for creating new case type by the name of `default prospect workflow ` but the `case_type_category` field is not a core field so while installation of the extension this field does not get updated through api so a custom mysql query has been added to update this field.

NOTE: A new task will be created to fix the failing frontend tests on this extension.