### PR TITLE
CPS-421: Fix unit tests

### DIFF
--- a/ang/test/karma.conf.js
+++ b/ang/test/karma.conf.js
@@ -27,12 +27,14 @@ module.exports = (config) => {
       // Global variables that need to be accessible in the test environment
       `${extPath}/ang/test/global.js`,
 
-      // Source Files
+      // Civicase files
       civicasePath + '/ang/civicase-base.js',
-      { pattern: civicasePath + '/ang/civicase-base/**/*.js' },
-      // @Todo: extensions should only depend on civicase-base:
       civicasePath + '/ang/civicase.js',
+      { pattern: civicasePath + '/ang/test/mocks/modules.mock.js' },
+      { pattern: civicasePath + '/ang/test/mocks/**/*.js' },
+      { pattern: civicasePath + '/ang/civicase-base/**/*.js' },
 
+      // Source Files
       `${extPath}/ang/prospect.js`,
       { pattern: `${extPath}/ang/prospect/**/*.js` },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3338,14 +3338,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3360,20 +3358,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3490,8 +3485,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3503,7 +3497,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3518,7 +3511,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3526,14 +3518,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3552,7 +3542,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3633,8 +3622,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3646,7 +3634,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3768,7 +3755,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
## Overview
This PR fixes unit tests since they were breaking due to recent Civicase updates.

## Before
<img width="1733" alt="Screen Shot 2020-12-22 at 8 17 21 PM" src="https://user-images.githubusercontent.com/1642119/102944974-d090da00-4492-11eb-8fae-bba3f9f9446e.png">

## After
<img width="1721" alt="Screen Shot 2020-12-22 at 8 16 53 PM" src="https://user-images.githubusercontent.com/1642119/102944983-d4bcf780-4492-11eb-811f-97cf9eedacee.png">

## Technical Details
The issue started happening after the introduction of this change:
https://github.com/compucorp/uk.co.compucorp.civicase/commit/98afae651121b136243b3a35d56182cc2457b812#diff-667a41e3e5ef4fd00937fbb0ce466e64ee2e4c7b1da9d317df5f41224e1239d7R12

Since the constants file now depended on a value provided by `ang/test/mocks/data/crm.data.js` we needed to include this file. We update the mock files inclusion.

Also, The `@Todo` was ignored because there is no way to include `civicase` by just including `civicase-base`.
