### PR TITLE
COMCL-101: Regenerate civix file and Base upgrader class

### DIFF
--- a/CRM/Prospect/Upgrader/Base.php
+++ b/CRM/Prospect/Upgrader/Base.php
@@ -9,9 +9,9 @@ use CRM_Prospect_ExtensionUtil as E;
 class CRM_Prospect_Upgrader_Base {
 
   /**
-   * @var varies, subclass of this
+   * @var CRM_Prospect_Upgrader_Base
    */
-  static $instance;
+  public static $instance;
 
   /**
    * @var CRM_Queue_TaskContext
@@ -19,22 +19,25 @@ class CRM_Prospect_Upgrader_Base {
   protected $ctx;
 
   /**
-   * @var string, eg 'com.example.myextension'
+   * @var string
+   *   eg 'com.example.myextension'
    */
   protected $extensionName;
 
   /**
-   * @var string, full path to the extension's source tree
+   * @var string
+   *   full path to the extension's source tree
    */
   protected $extensionDir;
 
   /**
-   * @var array(revisionNumber) sorted numerically
+   * @var array
+   *   sorted numerically
    */
   private $revisions;
 
   /**
-   * @var boolean
+   * @var bool
    *   Flag to clean up extension revision data in civicrm_setting
    */
   private $revisionStorageIsDeprecated = FALSE;
@@ -42,12 +45,11 @@ class CRM_Prospect_Upgrader_Base {
   /**
    * Obtain a reference to the active upgrade handler.
    */
-  static public function instance() {
+  public static function instance() {
     if (!self::$instance) {
-      // FIXME auto-generate
       self::$instance = new CRM_Prospect_Upgrader(
         'uk.co.compucorp.civicrm.prospect',
-        realpath(__DIR__ . '/../../../')
+        E::path()
       );
     }
     return self::$instance;
@@ -59,19 +61,25 @@ class CRM_Prospect_Upgrader_Base {
    * Note: Each upgrader instance should only be associated with one
    * task-context; otherwise, this will be non-reentrant.
    *
-   * @code
+   * ```
    * CRM_Prospect_Upgrader_Base::_queueAdapter($ctx, 'methodName', 'arg1', 'arg2');
-   * @endcode
+   * ```
    */
-  static public function _queueAdapter() {
+  public static function _queueAdapter() {
     $instance = self::instance();
     $args = func_get_args();
     $instance->ctx = array_shift($args);
     $instance->queue = $instance->ctx->queue;
     $method = array_shift($args);
-    return call_user_func_array(array($instance, $method), $args);
+    return call_user_func_array([$instance, $method], $args);
   }
 
+  /**
+   * CRM_Prospect_Upgrader_Base constructor.
+   *
+   * @param $extensionName
+   * @param $extensionDir
+   */
   public function __construct($extensionName, $extensionDir) {
     $this->extensionName = $extensionName;
     $this->extensionDir = $extensionDir;
@@ -82,7 +90,8 @@ class CRM_Prospect_Upgrader_Base {
   /**
    * Run a CustomData file.
    *
-   * @param string $relativePath the CustomData XML file path (relative to this extension's dir)
+   * @param string $relativePath
+   *   the CustomData XML file path (relative to this extension's dir)
    * @return bool
    */
   public function executeCustomDataFile($relativePath) {
@@ -93,11 +102,12 @@ class CRM_Prospect_Upgrader_Base {
   /**
    * Run a CustomData file
    *
-   * @param string $xml_file  the CustomData XML file path (absolute path)
+   * @param string $xml_file
+   *   the CustomData XML file path (absolute path)
    *
    * @return bool
    */
-  protected static function executeCustomDataFileByAbsPath($xml_file) {
+  protected function executeCustomDataFileByAbsPath($xml_file) {
     $import = new CRM_Utils_Migrate_Import();
     $import->run($xml_file);
     return TRUE;
@@ -106,7 +116,8 @@ class CRM_Prospect_Upgrader_Base {
   /**
    * Run a SQL file.
    *
-   * @param string $relativePath the SQL file path (relative to this extension's dir)
+   * @param string $relativePath
+   *   the SQL file path (relative to this extension's dir)
    *
    * @return bool
    */
@@ -119,10 +130,14 @@ class CRM_Prospect_Upgrader_Base {
   }
 
   /**
+   * Run the sql commands in the specified file.
+   *
    * @param string $tplFile
    *   The SQL file path (relative to this extension's dir).
    *   Ex: "sql/mydata.mysql.tpl".
+   *
    * @return bool
+   * @throws \CRM_Core_Exception
    */
   public function executeSqlTemplate($tplFile) {
     // Assign multilingual variable to Smarty.
@@ -141,17 +156,19 @@ class CRM_Prospect_Upgrader_Base {
    * Run one SQL query.
    *
    * This is just a wrapper for CRM_Core_DAO::executeSql, but it
-   * provides syntatic sugar for queueing several tasks that
+   * provides syntactic sugar for queueing several tasks that
    * run different queries
+   *
+   * @return bool
    */
-  public function executeSql($query, $params = array()) {
+  public function executeSql($query, $params = []) {
     // FIXME verify that we raise an exception on error
     CRM_Core_DAO::executeQuery($query, $params);
     return TRUE;
   }
 
   /**
-   * Syntatic sugar for enqueuing a task which calls a function in this class.
+   * Syntactic sugar for enqueuing a task which calls a function in this class.
    *
    * The task is weighted so that it is processed
    * as part of the currently-pending revision.
@@ -163,11 +180,11 @@ class CRM_Prospect_Upgrader_Base {
     $args = func_get_args();
     $title = array_shift($args);
     $task = new CRM_Queue_Task(
-      array(get_class($this), '_queueAdapter'),
+      [get_class($this), '_queueAdapter'],
       $args,
       $title
     );
-    return $this->queue->createItem($task, array('weight' => -1));
+    return $this->queue->createItem($task, ['weight' => -1]);
   }
 
   // ******** Revision-tracking helpers ********
@@ -193,6 +210,8 @@ class CRM_Prospect_Upgrader_Base {
 
   /**
    * Add any pending revisions to the queue.
+   *
+   * @param CRM_Queue_Queue $queue
    */
   public function enqueuePendingRevisions(CRM_Queue_Queue $queue) {
     $this->queue = $queue;
@@ -200,23 +219,23 @@ class CRM_Prospect_Upgrader_Base {
     $currentRevision = $this->getCurrentRevision();
     foreach ($this->getRevisions() as $revision) {
       if ($revision > $currentRevision) {
-        $title = ts('Upgrade %1 to revision %2', array(
+        $title = E::ts('Upgrade %1 to revision %2', [
           1 => $this->extensionName,
           2 => $revision,
-        ));
+        ]);
 
         // note: don't use addTask() because it sets weight=-1
 
         $task = new CRM_Queue_Task(
-          array(get_class($this), '_queueAdapter'),
-          array('upgrade_' . $revision),
+          [get_class($this), '_queueAdapter'],
+          ['upgrade_' . $revision],
           $title
         );
         $this->queue->createItem($task);
 
         $task = new CRM_Queue_Task(
-          array(get_class($this), '_queueAdapter'),
-          array('setCurrentRevision', $revision),
+          [get_class($this), '_queueAdapter'],
+          ['setCurrentRevision', $revision],
           $title
         );
         $this->queue->createItem($task);
@@ -227,11 +246,12 @@ class CRM_Prospect_Upgrader_Base {
   /**
    * Get a list of revisions.
    *
-   * @return array(revisionNumbers) sorted numerically
+   * @return array
+   *   revisionNumbers sorted numerically
    */
   public function getRevisions() {
     if (!is_array($this->revisions)) {
-      $this->revisions = array();
+      $this->revisions = [];
 
       $clazz = new ReflectionClass(get_class($this));
       $methods = $clazz->getMethods();
@@ -256,7 +276,7 @@ class CRM_Prospect_Upgrader_Base {
 
   private function getCurrentRevisionDeprecated() {
     $key = $this->extensionName . ':version';
-    if ($revision = CRM_Core_BAO_Setting::getItem('Extension', $key)) {
+    if ($revision = \Civi::settings()->get($key)) {
       $this->revisionStorageIsDeprecated = TRUE;
     }
     return $revision;
@@ -281,7 +301,7 @@ class CRM_Prospect_Upgrader_Base {
   // ******** Hook delegates ********
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
    */
   public function onInstall() {
     $files = glob($this->extensionDir . '/sql/*_install.sql');
@@ -302,26 +322,26 @@ class CRM_Prospect_Upgrader_Base {
         $this->executeCustomDataFileByAbsPath($file);
       }
     }
-    if (is_callable(array($this, 'install'))) {
+    if (is_callable([$this, 'install'])) {
       $this->install();
     }
   }
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
    */
   public function onPostInstall() {
     $revisions = $this->getRevisions();
     if (!empty($revisions)) {
       $this->setCurrentRevision(max($revisions));
     }
-    if (is_callable(array($this, 'postInstall'))) {
+    if (is_callable([$this, 'postInstall'])) {
       $this->postInstall();
     }
   }
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
    */
   public function onUninstall() {
     $files = glob($this->extensionDir . '/sql/*_uninstall.mysql.tpl');
@@ -330,7 +350,7 @@ class CRM_Prospect_Upgrader_Base {
         $this->executeSqlTemplate($file);
       }
     }
-    if (is_callable(array($this, 'uninstall'))) {
+    if (is_callable([$this, 'uninstall'])) {
       $this->uninstall();
     }
     $files = glob($this->extensionDir . '/sql/*_uninstall.sql');
@@ -342,21 +362,21 @@ class CRM_Prospect_Upgrader_Base {
   }
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
    */
   public function onEnable() {
     // stub for possible future use
-    if (is_callable(array($this, 'enable'))) {
+    if (is_callable([$this, 'enable'])) {
       $this->enable();
     }
   }
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
    */
   public function onDisable() {
     // stub for possible future use
-    if (is_callable(array($this, 'disable'))) {
+    if (is_callable([$this, 'disable'])) {
       $this->disable();
     }
   }
@@ -364,7 +384,7 @@ class CRM_Prospect_Upgrader_Base {
   public function onUpgrade($op, CRM_Queue_Queue $queue = NULL) {
     switch ($op) {
       case 'check':
-        return array($this->hasPendingRevisions());
+        return [$this->hasPendingRevisions()];
 
       case 'enqueue':
         return $this->enqueuePendingRevisions($queue);

--- a/prospect.civix.php
+++ b/prospect.civix.php
@@ -1,17 +1,15 @@
 <?php
 
-/**
- * @file
- * AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file.
- */
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
- * The class provides small stubs for accessing resources of this extension.
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
  */
 class CRM_Prospect_ExtensionUtil {
-  const SHORT_NAME = "prospect";
-  const LONG_NAME = "uk.co.compucorp.civicrm.prospect";
-  const CLASS_PREFIX = "CRM_Prospect";
+  const SHORT_NAME = 'prospect';
+  const LONG_NAME = 'uk.co.compucorp.civicrm.prospect';
+  const CLASS_PREFIX = 'CRM_Prospect';
 
   /**
    * Translate a string using the extension's domain.
@@ -22,14 +20,11 @@ class CRM_Prospect_ExtensionUtil {
    * @param string $text
    *   Canonical message text (generally en_US).
    * @param array $params
-   *   Parameters.
-   *
    * @return string
    *   Translated text.
-   *
    * @see ts
    */
-  public static function ts($text, array $params = []) {
+  public static function ts($text, $params = []) {
     if (!array_key_exists('domain', $params)) {
       $params['domain'] = [self::LONG_NAME, NULL];
     }
@@ -39,10 +34,9 @@ class CRM_Prospect_ExtensionUtil {
   /**
    * Get the URL of a resource file (in this extension).
    *
-   * @param string|null $file
+   * @param string|NULL $file
    *   Ex: NULL.
    *   Ex: 'css/foo.css'.
-   *
    * @return string
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
@@ -57,16 +51,15 @@ class CRM_Prospect_ExtensionUtil {
   /**
    * Get the path of a resource file (in this extension).
    *
-   * @param string|null $file
+   * @param string|NULL $file
    *   Ex: NULL.
    *   Ex: 'css/foo.css'.
-   *
    * @return string
    *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
    *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
   public static function path($file = NULL) {
-    // Return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file).
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
     return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
   }
 
@@ -75,7 +68,6 @@ class CRM_Prospect_ExtensionUtil {
    *
    * @param string $suffix
    *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
-   *
    * @return string
    *   Ex: 'CRM_Foo_Page_HelloWorld'.
    */
@@ -88,9 +80,9 @@ class CRM_Prospect_ExtensionUtil {
 use CRM_Prospect_ExtensionUtil as E;
 
 /**
- * Delegated - Implements hook_civicrm_config().
+ * (Delegated) Implements hook_civicrm_config().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
 function _prospect_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
@@ -116,14 +108,13 @@ function _prospect_civix_civicrm_config(&$config = NULL) {
 }
 
 /**
- * Delegated - Implements hook_civicrm_xmlMenu().
+ * (Delegated) Implements hook_civicrm_xmlMenu().
  *
- * @param array $files
- *   Files.
+ * @param $files array(string)
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
  */
-function _prospect_civix_civicrm_xmlMenu(array &$files) {
+function _prospect_civix_civicrm_xmlMenu(&$files) {
   foreach (_prospect_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
     $files[] = $file;
   }
@@ -132,7 +123,7 @@ function _prospect_civix_civicrm_xmlMenu(array &$files) {
 /**
  * Implements hook_civicrm_install().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _prospect_civix_civicrm_install() {
   _prospect_civix_civicrm_config();
@@ -144,7 +135,7 @@ function _prospect_civix_civicrm_install() {
 /**
  * Implements hook_civicrm_postInstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
 function _prospect_civix_civicrm_postInstall() {
   _prospect_civix_civicrm_config();
@@ -158,7 +149,7 @@ function _prospect_civix_civicrm_postInstall() {
 /**
  * Implements hook_civicrm_uninstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
 function _prospect_civix_civicrm_uninstall() {
   _prospect_civix_civicrm_config();
@@ -168,9 +159,9 @@ function _prospect_civix_civicrm_uninstall() {
 }
 
 /**
- * Delegated - Implements hook_civicrm_enable().
+ * (Delegated) Implements hook_civicrm_enable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _prospect_civix_civicrm_enable() {
   _prospect_civix_civicrm_config();
@@ -182,9 +173,10 @@ function _prospect_civix_civicrm_enable() {
 }
 
 /**
- * Delegated - Implements hook_civicrm_disable().
+ * (Delegated) Implements hook_civicrm_disable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
+ * @return mixed
  */
 function _prospect_civix_civicrm_disable() {
   _prospect_civix_civicrm_config();
@@ -196,19 +188,16 @@ function _prospect_civix_civicrm_disable() {
 }
 
 /**
- * Delegated - Implements hook_civicrm_upgrade().
+ * (Delegated) Implements hook_civicrm_upgrade().
  *
- * @param string $op
- *   The type of operation being performed; 'check' or 'enqueue'.
- * @param CRM_Queue_Queue $queue
- *   For 'enqueue' - the modifiable list of pending up upgrade tasks.
+ * @param $op string, the type of operation being performed; 'check' or 'enqueue'
+ * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
  * @return mixed
- *   Based on op. for 'check', returns array(boolean)
- *   (TRUE if upgrades are pending)
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
  *   for 'enqueue', returns void
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _prospect_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _prospect_civix_upgrader()) {
@@ -217,10 +206,7 @@ function _prospect_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
 }
 
 /**
- * Upgraders.
- *
  * @return CRM_Prospect_Upgrader
- *   Upgrader Instance.
  */
 function _prospect_civix_upgrader() {
   if (!file_exists(__DIR__ . '/CRM/Prospect/Upgrader.php')) {
@@ -237,13 +223,10 @@ function _prospect_civix_upgrader() {
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
  * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
  *
- * @param string $dir
- *   Base dir.
- * @param string $pattern
- *   Glob pattern, eg "*.txt".
+ * @param string $dir base dir
+ * @param string $pattern , glob pattern, eg "*.txt"
  *
  * @return array
- *   Files.
  */
 function _prospect_civix_find_files($dir, $pattern) {
   if (is_callable(['CRM_Utils_File', 'findFiles'])) {
@@ -262,7 +245,7 @@ function _prospect_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         }
         elseif (is_dir($path)) {
           $todos[] = $path;
@@ -275,11 +258,11 @@ function _prospect_civix_find_files($dir, $pattern) {
 }
 
 /**
- * Delegated - Implements hook_civicrm_managed().
+ * (Delegated) Implements hook_civicrm_managed().
  *
  * Find any *.mgd.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
  */
 function _prospect_civix_civicrm_managed(&$entities) {
   $mgdFiles = _prospect_civix_find_files(__DIR__, '*.mgd.php');
@@ -299,13 +282,13 @@ function _prospect_civix_civicrm_managed(&$entities) {
 }
 
 /**
- * Delegated - Implements hook_civicrm_caseTypes().
+ * (Delegated) Implements hook_civicrm_caseTypes().
  *
  * Find any and return any files matching "xml/case/*.xml"
  *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _prospect_civix_civicrm_caseTypes(&$caseTypes) {
   if (!is_dir(__DIR__ . '/xml/case')) {
@@ -316,8 +299,7 @@ function _prospect_civix_civicrm_caseTypes(&$caseTypes) {
     $name = preg_replace('/\.xml$/', '', basename($file));
     if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
       $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      CRM_Core_Error::fatal($errorMessage);
-      // Throw new CRM_Core_Exception($errorMessage);
+      throw new CRM_Core_Exception($errorMessage);
     }
     $caseTypes[$name] = [
       'module' => E::LONG_NAME,
@@ -328,28 +310,15 @@ function _prospect_civix_civicrm_caseTypes(&$caseTypes) {
 }
 
 /**
- * Delegated - Implements hook_civicrm_angularModules().
+ * (Delegated) Implements hook_civicrm_angularModules().
  *
  * Find any and return any files matching "ang/*.ang.php"
  *
  * Note: This hook only runs in CiviCRM 4.5+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _prospect_civix_civicrm_angularModules(&$angularModules) {
-  _prospect_includeAngularModules($angularModules);
-}
-
-/**
- * Add Angular Modules.
- *
- * Find and return files matching "ang/*.ang.php" and includes them as
- * angular modules.
- *
- * @param array $angularModules
- *   Angular Modules.
- */
-function _prospect_includeAngularModules(array &$angularModules) {
   if (!is_dir(__DIR__ . '/ang')) {
     return;
   }
@@ -366,6 +335,25 @@ function _prospect_includeAngularModules(array &$angularModules) {
 }
 
 /**
+ * (Delegated) Implements hook_civicrm_themes().
+ *
+ * Find any and return any files matching "*.theme.php"
+ */
+function _prospect_civix_civicrm_themes(&$themes) {
+  $files = _prospect_civix_glob(__DIR__ . '/*.theme.php');
+  foreach ($files as $file) {
+    $themeMeta = include $file;
+    if (empty($themeMeta['name'])) {
+      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+    }
+    if (empty($themeMeta['ext'])) {
+      $themeMeta['ext'] = E::LONG_NAME;
+    }
+    $themes[$themeMeta['name']] = $themeMeta;
+  }
+}
+
+/**
  * Glob wrapper which is guaranteed to return an array.
  *
  * The documentation for glob() says, "On some systems it is impossible to
@@ -374,12 +362,9 @@ function _prospect_includeAngularModules(array &$angularModules) {
  * This wrapper provides consistency.
  *
  * @link http://php.net/glob
- *
  * @param string $pattern
- *   Pattern.
  *
  * @return array
- *   possibly empty
  */
 function _prospect_civix_glob($pattern) {
   $result = glob($pattern);
@@ -389,16 +374,16 @@ function _prospect_civix_glob($pattern) {
 /**
  * Inserts a navigation menu item at a given place in the hierarchy.
  *
- * @param array $menu
- *   Menu hierarchy.
- * @param string $path
- *   Path to parent of this item, e.g. 'my_extension/submenu'
- *   'Mailing', or 'Administer/System Settings'.
- * @param array $item
- *   The item to insert (parent/child attributes will be filled for you).
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
  */
-function _prospect_civix_insert_navigation_menu(array &$menu, $path, array $item) {
-  // If we are done going down the path, insert menu.
+function _prospect_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
   if (empty($path)) {
     $menu[] = [
       'attributes' => array_merge([
@@ -409,7 +394,7 @@ function _prospect_civix_insert_navigation_menu(array &$menu, $path, array $item
     return TRUE;
   }
   else {
-    // Find an recurse into the next level down.
+    // Find an recurse into the next level down
     $found = FALSE;
     $path = explode('/', $path);
     $first = array_shift($path);
@@ -418,7 +403,7 @@ function _prospect_civix_insert_navigation_menu(array &$menu, $path, array $item
         if (!isset($entry['child'])) {
           $entry['child'] = [];
         }
-        $found = _prospect_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        $found = _prospect_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
@@ -426,7 +411,7 @@ function _prospect_civix_insert_navigation_menu(array &$menu, $path, array $item
 }
 
 /**
- * Delegated - Implements hook_civicrm_navigationMenu().
+ * (Delegated) Implements hook_civicrm_navigationMenu().
  */
 function _prospect_civix_navigationMenu(&$nodes) {
   if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
@@ -435,14 +420,12 @@ function _prospect_civix_navigationMenu(&$nodes) {
 }
 
 /**
- * Fix Navigation Menu.
- *
  * Given a navigation menu, generate navIDs for any items which are
  * missing them.
  */
 function _prospect_civix_fixNavigationMenu(&$nodes) {
   $maxNavID = 1;
-  array_walk_recursive($nodes, function ($item, $key) use (&$maxNavID) {
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
     if ($key === 'navID') {
       $maxNavID = max($maxNavID, $item);
     }
@@ -450,9 +433,6 @@ function _prospect_civix_fixNavigationMenu(&$nodes) {
   _prospect_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
 }
 
-/**
- * Fix Navigation Menu Items.
- */
 function _prospect_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
   $origKeys = array_keys($nodes);
   foreach ($origKeys as $origKey) {
@@ -474,34 +454,27 @@ function _prospect_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) 
 }
 
 /**
- * Delegated - Implements hook_civicrm_alterSettingsFolders().
+ * (Delegated) Implements hook_civicrm_alterSettingsFolders().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
  */
 function _prospect_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
-
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }
 
 /**
- * Delegated - Implements hook_civicrm_entityTypes().
+ * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
 function _prospect_civix_civicrm_entityTypes(&$entityTypes) {
   $entityTypes = array_merge($entityTypes, [
-    'CRM_Prospect_DAO_ProspectConverted' =>
-    [
+    'CRM_Prospect_DAO_ProspectConverted' => [
       'name' => 'ProspectConverted',
       'class' => 'CRM_Prospect_DAO_ProspectConverted',
       'table' => 'civicrm_prospect_converted',


### PR DESCRIPTION
## Overview

This PR fixes is to updates civix file and an upgrader base class.  The base class and civix file are generated automatically by running `civix generate:upgrader
`
The reason for regenerating the civix file and base upgrader class because CiviCRM changed the way they handle warning for using a deprecated function.  See this [PR ](https://github.com/civicrm/civicrm-core/pull/19256).

The changed will always throw use deprecated warning if the deprecated function is used in anywhere, for example, Drupal module, CiviCRM extension. This would not have an issue we install the extension / module via user interface. However, when we use Drush site-install command to install the Drupal site that ship with a Drupal profile that install the extension when creating a site. 

Any module or extension that use CiviCRM's deprecated function in the installation hook, upgrade hook, the E_USER_DEPRECATED warning will throw during installation, but Drush handles deprecated messages as an error rather than a warning.  

Since the old civix file and Base class are using the deprecated functions, we will also receive the error duration installation, for this reason, the deployment will always fail. This PR fixes this.  

### Note 

PR for fixing this issue in Drush has been created and merged to Druah 8.x https://github.com/drush-ops/drush/pull/4565, but we do not have a timescale for new Drush version to release, thus we fixed the extension. 

