### PR TITLE
CPS-203: Allow Long Case Category Names For Menus

### DIFF
--- a/CRM/Prospect/Service/ProspectingMenu.php
+++ b/CRM/Prospect/Service/ProspectingMenu.php
@@ -1,0 +1,48 @@
+<?php
+
+use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
+
+/**
+ * Prospecting Menu class.
+ */
+class CRM_Prospect_Service_ProspectingMenu extends CRM_Civicase_Service_CaseCategoryMenu {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getSubmenus($caseTypeCategoryName, array $permissions = NULL) {
+    $categoryId = civicrm_api3('OptionValue', 'getsingle', [
+      'option_group_id' => 'case_type_categories',
+      'name' => $caseTypeCategoryName,
+      'return' => ['value'],
+    ])['value'];
+    if (!$permissions) {
+      $permissions = (new CaseCategoryPermission())->get($caseTypeCategoryName);
+    }
+
+    return [
+      [
+        'label' => ts('Dashboard'),
+        'name' => 'prospect_dashboard',
+        'url' => 'civicrm/case/a/?case_type_category=' . $categoryId . '#/case?case_type_category=' . $categoryId,
+        'permission' => "{$permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
+        'permission_operator' => 'OR',
+      ],
+      [
+        'label' => ts('New Prospect'),
+        'name' => 'new_prospect',
+        'url' => 'civicrm/case/add?case_type_category=' . $categoryId . '&action=add&reset=1&context=standalone',
+        'permission' => "{$permissions['ADD_CASE_CATEGORY']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
+        'permission_operator' => 'OR',
+      ],
+      [
+        'label' => ts('Manage Prospects'),
+        'name' => 'manage_prospect',
+        'url' => 'civicrm/case/a/?case_type_category=' . $categoryId . '#/case/list?cf=%7B"case_type_category":"' . $categoryId . '"%7D',
+        'permission' => "{$permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
+        'permission_operator' => 'OR',
+      ],
+    ];
+  }
+
+}

--- a/CRM/Prospect/Setup/CreateProspectMenus.php
+++ b/CRM/Prospect/Setup/CreateProspectMenus.php
@@ -1,5 +1,8 @@
 <?php
 
+use CRM_Prospect_Service_ProspectingMenu as ProspectingMenu;
+use CRM_Prospect_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
 /**
  * Create Prospect Menu items.
  */
@@ -7,90 +10,9 @@ class CRM_Prospect_Setup_CreateProspectMenus {
 
   /**
    * Creates the Prospect menu items.
-   *
-   * @return bool
-   *   Returns TRUE
    */
   public function apply() {
-    $this->createProspectMenuItems();
-
-    return TRUE;
-  }
-
-  /**
-   * Creates Prospect Main menu.
-   */
-  private function createProspectMenuItems() {
-    $result = civicrm_api3('Navigation', 'get', ['name' => 'prospects']);
-
-    if ($result['count'] > 0) {
-      return;
-    }
-
-    $casesWeight = CRM_Core_DAO::getFieldValue(
-      'CRM_Core_DAO_Navigation',
-      'Cases',
-      'weight',
-      'name'
-    );
-
-    $params = [
-      'label' => ts('Prospects'),
-      'name' => 'prospects',
-      'url' => NULL,
-      'permission_operator' => 'OR',
-      'is_active' => 1,
-      'permission' => 'access my prospecting and activities,access all prospecting and activities',
-      'icon' => 'crm-i fa-folder-open-o',
-    ];
-
-    $prospectMenu = civicrm_api3('Navigation', 'create', $params);
-    // Menu weight seems to be ignored on create irrespective of whatever is
-    // passed, Civi will assign the next available weight. This fixes the issue.
-    civicrm_api3('Navigation', 'create', [
-      'id' => $prospectMenu['id'],
-      'weight' => $casesWeight + 1,
-    ]);
-    $this->createProspectSubmenus($prospectMenu['id']);
-  }
-
-  /**
-   * Creates Prospect sub menu items.
-   *
-   * @param int $prospectMenuId
-   *   Prospect menu id.
-   */
-  private function createProspectSubmenus($prospectMenuId) {
-    $submenus = [
-      [
-        'label' => ts('Dashboard'),
-        'name' => 'prospect_dashboard',
-        'url' => 'civicrm/case/a/?case_type_category=prospecting#/case?case_type_category=prospecting',
-        'permission' => 'access my prospecting and activities,access all prospecting and activities',
-        'permission_operator' => 'OR',
-      ],
-      [
-        'label' => ts('New Prospect'),
-        'name' => 'new_prospect',
-        'url' => 'civicrm/case/add?case_type_category=prospecting&action=add&reset=1&context=standalone',
-        'permission' => 'add prospecting,access all prospecting and activities',
-        'permission_operator' => 'OR',
-      ],
-      [
-        'label' => ts('Manage Prospects'),
-        'name' => 'manage_prospect',
-        'url' => 'civicrm/case/a/?case_type_category=prospecting#/case/list?cf=%7B"case_type_category":"prospecting"%7D',
-        'permission' => 'access my prospecting and activities,access all prospecting and activities',
-        'permission_operator' => 'OR',
-      ],
-    ];
-
-    foreach ($submenus as $i => $item) {
-      $item['weight'] = $i;
-      $item['parent_id'] = $prospectMenuId;
-      $item['is_active'] = 1;
-      civicrm_api3('Navigation', 'create', $item);
-    }
+    (new ProspectingMenu())->createItems(CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME);
   }
 
 }

--- a/CRM/Prospect/Upgrader/Steps/Step1008.php
+++ b/CRM/Prospect/Upgrader/Steps/Step1008.php
@@ -14,7 +14,7 @@ class CRM_Prospect_Upgrader_Steps_Step1008 {
    *   Return value in boolean.
    */
   public function apply() {
-    (new ProspectingMenu())->updateCaseCategorySubmenus(
+    (new ProspectingMenu())->resetCaseCategorySubmenusUrl(
         CRM_Prospect_Helper_CaseTypeCategory::PROSPECT_CASE_TYPE_CATEGORY_NAME
     );
 

--- a/CRM/Prospect/Upgrader/Steps/Step1008.php
+++ b/CRM/Prospect/Upgrader/Steps/Step1008.php
@@ -1,0 +1,26 @@
+<?php
+
+use CRM_Prospect_Service_ProspectingMenu as ProspectingMenu;
+
+/**
+ * Update menus with new URL.
+ */
+class CRM_Prospect_Upgrader_Steps_Step1008 {
+
+  /**
+   * Runs the upgrader changes.
+   *
+   * @return bool
+   *   Return value in boolean.
+   */
+  public function apply() {
+    (new ProspectingMenu())->updateCaseCategorySubmenus(
+        CRM_Prospect_Helper_CaseTypeCategory::PROSPECT_CASE_TYPE_CATEGORY_NAME
+    );
+
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return TRUE;
+  }
+
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<phpunit
+  backupGlobals="false"
+  backupStaticAttributes="false"
+  colors="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  processIsolation="false"
+  stopOnFailure="false"
+  syntaxCheck="false"
+  bootstrap="tests/phpunit/bootstrap.php"
+>
+  <testsuites>
+    <testsuite name="Full">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements
+    HeadlessInterface,
+    TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->install('uk.co.compucorp.civicase')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,64 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=classloader', 'phpcode'));
+
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+require_once 'BaseHeadlessTest.php';
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -2,8 +2,9 @@
 
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
+// phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
-
+// phpcs:enable
 // Allow autoloading of PHPUnit helper classes in this extension.
 $loader = new \Composer\Autoload\ClassLoader();
 $loader->add('CRM_', __DIR__);


### PR DESCRIPTION
## Overview
The main purpose of this PR is to align Prospect code with the changes introduced on CiviCase, for allowing the usage of long Case Category names.

## Technical Details
PR for CiviCase: https://github.com/compucorp/uk.co.compucorp.civicase/pull/756

The changes here include.
- Add base code for unit test.
- Add a specific menu of prospect type. The "Prospecting" category instance is still not fully functional, because this extension still require some work, but the change provides consistency with other repositories and eliminates duplicated code. 
- Add upgrader for updating existing menus.
