### PR TITLE
CPS-554: Instance Support for Prospect

### DIFF
--- a/CRM/Prospect/Helper/CaseTypeCategory.php
+++ b/CRM/Prospect/Helper/CaseTypeCategory.php
@@ -5,6 +5,7 @@
  */
 class CRM_Prospect_Helper_CaseTypeCategory {
 
+  const PROSPECT_INSTANCE_NAME = 'prospect_management';
   const PROSPECT_CASE_TYPE_CATEGORY_NAME = 'Prospecting';
 
   /**

--- a/CRM/Prospect/Helper/CaseTypeCategory.php
+++ b/CRM/Prospect/Helper/CaseTypeCategory.php
@@ -5,7 +5,7 @@
  */
 class CRM_Prospect_Helper_CaseTypeCategory {
 
-  const PROSPECT_INSTANCE_NAME = 'prospect_management';
+  const PROSPECT_INSTANCE_NAME = 'sales_opportunity_tracking';
   const PROSPECT_CASE_TYPE_CATEGORY_NAME = 'Prospecting';
 
   /**

--- a/CRM/Prospect/Service/SalesOpportunityTrackingMenu.php
+++ b/CRM/Prospect/Service/SalesOpportunityTrackingMenu.php
@@ -1,16 +1,18 @@
 <?php
 
 use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
+use CRM_Prospect_Helper_CaseTypeCategory as CaseTypeCategory;
 
 /**
- * Prospecting Menu class.
+ * SalesOpportunityTracking Menu class.
  */
-class CRM_Prospect_Service_ProspectingMenu extends CRM_Civicase_Service_CaseCategoryMenu {
+class CRM_Prospect_Service_SalesOpportunityTrackingMenu extends CRM_Civicase_Service_CaseCategoryMenu {
 
   /**
    * {@inheritDoc}
    */
   public function getSubmenus($caseTypeCategoryName, array $permissions = NULL) {
+    $labelForMenu = ucfirst(strtolower($caseTypeCategoryName));
     $categoryId = civicrm_api3('OptionValue', 'getsingle', [
       'option_group_id' => 'case_type_categories',
       'name' => $caseTypeCategoryName,
@@ -20,26 +22,38 @@ class CRM_Prospect_Service_ProspectingMenu extends CRM_Civicase_Service_CaseCate
       $permissions = (new CaseCategoryPermission())->get($caseTypeCategoryName);
     }
 
+    $caseTypeCategoryName = ($caseTypeCategoryName === CaseTypeCategory::PROSPECT_CASE_TYPE_CATEGORY_NAME) ?
+      'prospect' :
+       $caseTypeCategoryName;
+
     return [
       [
         'label' => ts('Dashboard'),
-        'name' => 'prospect_dashboard',
+        'name' => "{$caseTypeCategoryName}_dashboard",
         'url' => 'civicrm/case/a/?case_type_category=' . $categoryId . '#/case?case_type_category=' . $categoryId,
         'permission' => "{$permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
         'permission_operator' => 'OR',
       ],
       [
-        'label' => ts('New Prospect'),
-        'name' => 'new_prospect',
+        'label' => ts("New {$labelForMenu}"),
+        'name' => "new_{$caseTypeCategoryName}",
         'url' => 'civicrm/case/add?case_type_category=' . $categoryId . '&action=add&reset=1&context=standalone',
         'permission' => "{$permissions['ADD_CASE_CATEGORY']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
         'permission_operator' => 'OR',
       ],
       [
-        'label' => ts('Manage Prospects'),
-        'name' => 'manage_prospect',
+        'label' => ts("Manage {$labelForMenu}"),
+        'name' => "manage_{$caseTypeCategoryName}",
         'url' => 'civicrm/case/a/?case_type_category=' . $categoryId . '#/case/list?cf=%7B"case_type_category":"' . $categoryId . '"%7D',
         'permission' => "{$permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
+        'permission_operator' => 'OR',
+        'has_separator' => 1,
+      ],
+      [
+        'label' => ts("Manage Workflows"),
+        'name' => "manage_{$caseTypeCategoryName}_workflows",
+        'url' => 'civicrm/workflow/a?case_type_category=' . $categoryId . '&p=al#/list',
+        'permission' => "{$permissions['ADMINISTER_CASE_CATEGORY']['name']}, administer CiviCRM",
         'permission_operator' => 'OR',
       ],
     ];

--- a/CRM/Prospect/Service/SalesOpportunityTrackingUtils.php
+++ b/CRM/Prospect/Service/SalesOpportunityTrackingUtils.php
@@ -1,0 +1,45 @@
+<?php
+
+use CRM_Prospect_Service_SalesOpportunityTrackingMenu as SalesOpportunityTrackingMenu;
+use CRM_Civicase_Service_CaseManagementCustomGroupPostProcessor as CaseManagementCustomGroupPostProcessor;
+use CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess as CaseManagementCustomGroupPostProcessHelper;
+use CRM_Civicase_Service_CaseManagementCaseTypePostProcessor as CaseManagementCaseTypePostProcessor;
+use CRM_Civicase_Service_CaseManagementCustomGroupDisplayFormatter as CaseManagementCustomGroupDisplayFormatter;
+
+/**
+ * SalesOpportunityTrackingUtils class for case instance type.
+ */
+class CRM_Prospect_Service_SalesOpportunityTrackingUtils extends CRM_Civicase_Service_CaseCategoryInstanceUtils {
+
+  /**
+   * Returns the menu object for the default category instance.
+   *
+   * @return \CRM_Prospect_Service_SalesOpportunityTrackingMenu
+   *   Menu object.
+   */
+  public function getMenuObject() {
+    return new SalesOpportunityTrackingMenu();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCaseTypePostProcessor() {
+    return new CaseManagementCaseTypePostProcessor(new CaseManagementCustomGroupPostProcessHelper());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCustomGroupDisplayFormatter() {
+    return new CaseManagementCustomGroupDisplayFormatter(new CaseManagementCustomGroupPostProcessHelper());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCustomGroupPostProcessor() {
+    return new CaseManagementCustomGroupPostProcessor(new CaseManagementCustomGroupPostProcessHelper());
+  }
+
+}

--- a/CRM/Prospect/Setup/AddManageWorkflowMenu.php
+++ b/CRM/Prospect/Setup/AddManageWorkflowMenu.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenu;
+use CRM_Civicase_Service_ManageWorkflowMenu as ManageWorkflowMenu;
 use CRM_Prospect_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 
 /**
@@ -12,21 +12,11 @@ class CRM_Prospect_Setup_AddManageWorkflowMenu {
    * Create Manage Workflow menu for Prospecting.
    */
   public function apply() {
-    $parentMenuForCaseCategory = civicrm_api3('Navigation', 'get', [
-      'sequential' => 1,
-      'label' => 'Prospects',
-    ])['values'][0];
-
-    if ($parentMenuForCaseCategory['id']) {
-      CaseCategoryMenu::addSeparatorToTheLastMenuOf(
-        $parentMenuForCaseCategory['id']
-      );
-      CaseCategoryMenu::createManageWorkflowMenuItemInto(
-        $parentMenuForCaseCategory['id'],
-        CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME,
-        'Manage Workflows'
-      );
-    }
+    (new ManageWorkflowMenu())->create(
+      CaseTypeCategoryHelper::PROSPECT_INSTANCE_NAME,
+      FALSE,
+      'Prospects'
+    );
   }
 
 }

--- a/CRM/Prospect/Setup/AddManageWorkflowMenu.php
+++ b/CRM/Prospect/Setup/AddManageWorkflowMenu.php
@@ -1,0 +1,32 @@
+<?php
+
+use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenu;
+use CRM_Prospect_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
+/**
+ * Adds the Manage Workflow Menu item for Prospect.
+ */
+class CRM_Prospect_Setup_AddManageWorkflowMenu {
+
+  /**
+   * Create Manage Workflow menu for Prospecting.
+   */
+  public function apply() {
+    $parentMenuForCaseCategory = civicrm_api3('Navigation', 'get', [
+      'sequential' => 1,
+      'label' => 'Prospects',
+    ])['values'][0];
+
+    if ($parentMenuForCaseCategory['id']) {
+      CaseCategoryMenu::addSeparatorToTheLastMenuOf(
+        $parentMenuForCaseCategory['id']
+      );
+      CaseCategoryMenu::createManageWorkflowMenuItemInto(
+        $parentMenuForCaseCategory['id'],
+        CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME,
+        'Manage Workflows'
+      );
+    }
+  }
+
+}

--- a/CRM/Prospect/Setup/CaseCategoryInstanceSupport.php
+++ b/CRM/Prospect/Setup/CaseCategoryInstanceSupport.php
@@ -1,0 +1,59 @@
+<?php
+
+use CRM_Civicase_Service_CaseCategoryInstance as CaseCategoryInstance;
+use CRM_Prospect_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
+/**
+ * Sets up Case Category Instance Support.
+ */
+class CRM_Prospect_Setup_CaseCategoryInstanceSupport {
+
+  const INSTANCE_OPTION_GROUP = 'case_category_instance_type';
+
+  /**
+   * Adds Case Category Instance Support.
+   */
+  public function apply() {
+    $this->createDefaultInstanceOptionValue();
+    $this->assignInstanceToProspect();
+  }
+
+  /**
+   * Create Default Instance Type option value.
+   */
+  private function createDefaultInstanceOptionValue() {
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists(
+      [
+        'option_group_id' => self::INSTANCE_OPTION_GROUP,
+        'name' => CaseTypeCategoryHelper::PROSPECT_INSTANCE_NAME,
+        'label' => 'Prospect Management',
+        'grouping' => 'CRM_Civicase_Service_CaseManagementUtils',
+        'is_active' => TRUE,
+        'is_reserved' => TRUE,
+      ]
+    );
+  }
+
+  /**
+   * Assign Instance to Prospect Case Type Category
+   */
+  private function assignInstanceToProspect () {
+    $prospectInstanceId = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => 'case_category_instance_type',
+      'name' => CaseTypeCategoryHelper::PROSPECT_INSTANCE_NAME,
+    ])['values'][0]['value'];
+
+    $prospectCaseTypeCategory = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => "case_type_categories",
+      'name' => CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME,
+    ])['values'][0];
+
+    CaseCategoryInstance::createInstanceTypeFor(
+      $prospectCaseTypeCategory['value'],
+      $prospectInstanceId
+    );
+  }
+
+}

--- a/CRM/Prospect/Setup/CaseCategoryInstanceSupport.php
+++ b/CRM/Prospect/Setup/CaseCategoryInstanceSupport.php
@@ -26,8 +26,8 @@ class CRM_Prospect_Setup_CaseCategoryInstanceSupport {
       [
         'option_group_id' => self::INSTANCE_OPTION_GROUP,
         'name' => CaseTypeCategoryHelper::PROSPECT_INSTANCE_NAME,
-        'label' => 'Prospect Management',
-        'grouping' => 'CRM_Civicase_Service_CaseManagementUtils',
+        'label' => 'Sales/Opportunity Tracking',
+        'grouping' => 'CRM_Prospect_Service_SalesOpportunityTrackingUtils',
         'is_active' => TRUE,
         'is_reserved' => TRUE,
       ]

--- a/CRM/Prospect/Setup/CreateProspectMenus.php
+++ b/CRM/Prospect/Setup/CreateProspectMenus.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_Prospect_Service_ProspectingMenu as ProspectingMenu;
+use CRM_Prospect_Service_SalesOpportunityTrackingMenu as SalesOpportunityTrackingMenu;
 use CRM_Prospect_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 
 /**
@@ -12,7 +12,7 @@ class CRM_Prospect_Setup_CreateProspectMenus {
    * Creates the Prospect menu items.
    */
   public function apply() {
-    (new ProspectingMenu())->createItems(CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME);
+    (new SalesOpportunityTrackingMenu())->createItems(CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME);
   }
 
 }

--- a/CRM/Prospect/Upgrader/Steps/Step1008.php
+++ b/CRM/Prospect/Upgrader/Steps/Step1008.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_Prospect_Service_ProspectingMenu as ProspectingMenu;
+use CRM_Prospect_Service_SalesOpportunityTrackingMenu as SalesOpportunityTrackingMenu;
 
 /**
  * Update menus with new URL.
@@ -14,7 +14,7 @@ class CRM_Prospect_Upgrader_Steps_Step1008 {
    *   Return value in boolean.
    */
   public function apply() {
-    (new ProspectingMenu())->resetCaseCategorySubmenusUrl(
+    (new SalesOpportunityTrackingMenu())->resetCaseCategorySubmenusUrl(
         CRM_Prospect_Helper_CaseTypeCategory::PROSPECT_CASE_TYPE_CATEGORY_NAME
     );
 

--- a/CRM/Prospect/Upgrader/Steps/Step1009.php
+++ b/CRM/Prospect/Upgrader/Steps/Step1009.php
@@ -1,0 +1,27 @@
+<?php
+
+use CRM_Prospect_Setup_CaseCategoryInstanceSupport as CaseCategoryInstanceSupport;
+use CRM_Prospect_Setup_AddManageWorkflowMenu as AddManageWorkflowMenu;
+
+/**
+ * Creates the Prospect instance type.
+ */
+class CRM_Prospect_Upgrader_Steps_Step1009 {
+
+  /**
+   * Add the Case category Instance support.
+   *
+   * @return bool
+   *   Return value in boolean.
+   */
+  public function apply() {
+    $caseInstanceStep = new CaseCategoryInstanceSupport();
+    $caseInstanceStep->apply();
+
+    $workflowMenuStep = new AddManageWorkflowMenu();
+    $workflowMenuStep->apply();
+
+    return TRUE;
+  }
+
+}

--- a/ang/prospect.ang.php
+++ b/ang/prospect.ang.php
@@ -17,7 +17,7 @@ function get_prospect_js_files() {
   return array_merge(
     ['ang/prospect.js'],
     GlobRecursive::getRelativeToExtension(
-      'uk.co.compucorp.civiawards',
+      'uk.co.compucorp.civicrm.prospect',
       'ang/prospect/*.js'
     )
   );

--- a/ang/prospect/app.constants.js
+++ b/ang/prospect/app.constants.js
@@ -3,6 +3,6 @@
 
   module.constant('ProspectGlobalValues', {
     caseTypeCategory: 'Prospecting',
-    instanceName: 'prospect_management'
+    instanceName: 'sales_opportunity_tracking'
   });
 })(angular);

--- a/ang/prospect/app.constants.js
+++ b/ang/prospect/app.constants.js
@@ -2,6 +2,7 @@
   var module = angular.module('prospect');
 
   module.constant('ProspectGlobalValues', {
-    caseTypeCategory: 'Prospecting'
+    caseTypeCategory: 'Prospecting',
+    instanceName: 'prospect_management'
   });
 })(angular);

--- a/ang/prospect/case-actions/services/convert-prospect-case-action.service.js
+++ b/ang/prospect/case-actions/services/convert-prospect-case-action.service.js
@@ -4,13 +4,9 @@
   module.service('ConvertProspectCaseAction', ConvertProspectCaseAction);
 
   /**
-   *
-   * @param {object} $location location service
-   * @param {object} crmApi crm api service
-   * @param {object} ProspectGlobalValues Prospect Global Values Constant
    * @param {object} ProspectConverted Prospect Converted Service
    */
-  function ConvertProspectCaseAction ($location, crmApi, ProspectGlobalValues, ProspectConverted) {
+  function ConvertProspectCaseAction (ProspectConverted) {
     var isConvertedToProspect = false;
 
     /**
@@ -43,7 +39,7 @@
         ['contribution', 'pledge'], action.type);
 
       return cases[0] && isPledgeOrContribution &&
-        ProspectConverted.checkIfProspectingCaseTypeCategory(cases[0]) &&
+        ProspectConverted.checkIfProspectManagementWorkflow(cases[0]['case_type_id.case_type_category']) &&
         !isConvertedToProspect;
     };
 

--- a/ang/prospect/case-actions/services/convert-prospect-case-action.service.js
+++ b/ang/prospect/case-actions/services/convert-prospect-case-action.service.js
@@ -39,7 +39,7 @@
         ['contribution', 'pledge'], action.type);
 
       return cases[0] && isPledgeOrContribution &&
-        ProspectConverted.checkIfProspectManagementWorkflow(cases[0]['case_type_id.case_type_category']) &&
+        ProspectConverted.checkIfSalesOpportunityTrackingWorkflow(cases[0]['case_type_id.case_type_category']) &&
         !isConvertedToProspect;
     };
 

--- a/ang/prospect/case-actions/services/convert-prospect-case-action.service.js
+++ b/ang/prospect/case-actions/services/convert-prospect-case-action.service.js
@@ -7,26 +7,6 @@
    * @param {object} ProspectConverted Prospect Converted Service
    */
   function ConvertProspectCaseAction (ProspectConverted) {
-    var isConvertedToProspect = false;
-
-    /**
-     * Refresh Data for the Service
-     *
-     * @param {Array} cases cases
-     */
-    this.refreshData = function (cases) {
-      if (!cases[0]) {
-        return;
-      }
-
-      var caseID = cases[0].id;
-
-      ProspectConverted.getProspectIsConverted(caseID)
-        .then(function (isConverted) {
-          isConvertedToProspect = isConverted;
-        });
-    };
-
     /**
      * Checks if the Action is allowed
      *
@@ -35,12 +15,16 @@
      * @returns {boolean} if action is allowed
      */
     this.isActionAllowed = function (action, cases) {
+      if (!cases[0] || !cases[0].prospect) {
+        return;
+      }
+
       var isPledgeOrContribution = _.includes(
         ['contribution', 'pledge'], action.type);
 
-      return cases[0] && isPledgeOrContribution &&
+      return isPledgeOrContribution &&
         ProspectConverted.checkIfSalesOpportunityTrackingWorkflow(cases[0]['case_type_id.case_type_category']) &&
-        !isConvertedToProspect;
+        !cases[0].prospect.isProspectConverted;
     };
 
     /**

--- a/ang/prospect/case-actions/services/view-pledge-contribution-case-action.service.js
+++ b/ang/prospect/case-actions/services/view-pledge-contribution-case-action.service.js
@@ -4,14 +4,9 @@
   module.service('ViewPledgeContributionCaseAction', ViewPledgeContributionCaseAction);
 
   /**
-   *
-   * @param {object} $location location service
-   * @param {object} crmApi crm api service
-   * @param {object} ProspectGlobalValues Prospect Global Values Constant
    * @param {object} ProspectConverted Prospect Converted Service
    */
-  function ViewPledgeContributionCaseAction (
-    $location, crmApi, ProspectGlobalValues, ProspectConverted) {
+  function ViewPledgeContributionCaseAction (ProspectConverted) {
     var isConvertedToProspect = false;
     var paymentInfo = {
       payment_completed: false,
@@ -65,7 +60,7 @@
         actionTypeMapping[action.type] === paymentInfo.payment_entity;
 
       return cases[0] &&
-        ProspectConverted.checkIfProspectingCaseTypeCategory(cases[0]) &&
+        ProspectConverted.checkIfProspectManagementWorkflow(cases[0]['case_type_id.case_type_category']) &&
         isConvertedToProspect && isPaymentTypeSameAsActionType;
     };
 

--- a/ang/prospect/case-actions/services/view-pledge-contribution-case-action.service.js
+++ b/ang/prospect/case-actions/services/view-pledge-contribution-case-action.service.js
@@ -60,7 +60,7 @@
         actionTypeMapping[action.type] === paymentInfo.payment_entity;
 
       return cases[0] &&
-        ProspectConverted.checkIfProspectManagementWorkflow(cases[0]['case_type_id.case_type_category']) &&
+        ProspectConverted.checkIfSalesOpportunityTrackingWorkflow(cases[0]['case_type_id.case_type_category']) &&
         isConvertedToProspect && isPaymentTypeSameAsActionType;
     };
 

--- a/ang/prospect/prospect-converted/decorators/case-details.decorators.js
+++ b/ang/prospect/prospect-converted/decorators/case-details.decorators.js
@@ -23,6 +23,8 @@
          * Listener for `updateCaseData` event
          */
         function updateCaseListener () {
+          $scope.item.prospect = {};
+
           var caseID = $scope.item.id;
 
           ProspectConverted.getProspectIsConverted(caseID)
@@ -30,6 +32,8 @@
               if (!isConverted) {
                 return;
               }
+
+              $scope.item.prospect.isProspectConverted = isConverted;
 
               ProspectConverted.getPaymentInfo(caseID)
                 .then(addExtraProspectField);
@@ -42,6 +46,7 @@
          * @param {object} paymentInfo payment info
          */
         function addExtraProspectField (paymentInfo) {
+          $scope.item.prospect.paymentInfo = paymentInfo;
           var financialInformationCustomField = _.find($scope.item.customData, function (customField) {
             return customField.name === 'Prospect_Financial_Information';
           });

--- a/ang/prospect/prospect-converted/services/prospect-converted.service.js
+++ b/ang/prospect/prospect-converted/services/prospect-converted.service.js
@@ -8,7 +8,7 @@
    *
    * @param {object} crmApi crm api
    * @param {*} ProspectGlobalValues prospect global values
-   * @param CaseTypeCategory
+   * @param {object} CaseTypeCategory case type category service
    */
   function ProspectConverted (crmApi, ProspectGlobalValues, CaseTypeCategory) {
     /**
@@ -41,13 +41,13 @@
     /**
      * Checks if Case Type Category is 'Prospecting'.
      *
-     * @param {object} caseData case data
+     * @param {string} caseTypeCategoryID case type category id
      * @returns {boolean} if prospect type category
      */
-    this.checkIfProspectingCaseTypeCategory = function (caseData) {
-      var caseTypeCategory = CaseTypeCategory.getAll()[caseData['case_type_id.case_type_category']].name;
+    this.checkIfProspectManagementWorkflow = function (caseTypeCategoryID) {
+      var instanceName = CaseTypeCategory.getCaseTypeCategoryInstance(caseTypeCategoryID).name;
 
-      return caseTypeCategory === ProspectGlobalValues.caseTypeCategory;
+      return instanceName === ProspectGlobalValues.instanceName;
     };
   }
 })(angular, CRM.$, CRM._);

--- a/ang/prospect/prospect-converted/services/prospect-converted.service.js
+++ b/ang/prospect/prospect-converted/services/prospect-converted.service.js
@@ -39,12 +39,12 @@
     };
 
     /**
-     * Checks if Case Type Category is 'Prospecting'.
+     * Checks if Case Type Category is Sales Opportunity Tracking type.
      *
      * @param {string} caseTypeCategoryID case type category id
      * @returns {boolean} if prospect type category
      */
-    this.checkIfProspectManagementWorkflow = function (caseTypeCategoryID) {
+    this.checkIfSalesOpportunityTrackingWorkflow = function (caseTypeCategoryID) {
       var instanceName = CaseTypeCategory.getCaseTypeCategoryInstance(caseTypeCategoryID).name;
 
       return instanceName === ProspectGlobalValues.instanceName;

--- a/ang/test/prospect/prospect-converted/services/prospect-converted.service.spec.js
+++ b/ang/test/prospect/prospect-converted/services/prospect-converted.service.spec.js
@@ -1,12 +1,8 @@
 /* eslint-env jasmine */
 
 describe('ProspectConverted', () => {
-  let crmApi;
-  let $q;
-  let $rootScope;
-  let PaymentInfoData;
-  let ProspectConverted;
-  let ProspectConvertedData;
+  let crmApi, $q, $rootScope, PaymentInfoData, ProspectConverted,
+    ProspectConvertedData;
 
   beforeEach(module('crmUtil', 'prospect', 'prospect.data'));
 
@@ -88,14 +84,12 @@ describe('ProspectConverted', () => {
     });
   });
 
-  describe('checkIfProspectingCaseTypeCategory()', () => {
+  describe('checkIfProspectManagementWorkflow()', () => {
     let returnValue;
 
     describe('when the case type category is prospect', () => {
       beforeEach(() => {
-        returnValue = ProspectConverted.checkIfProspectingCaseTypeCategory({
-          'case_type_id.case_type_category': 2
-        });
+        returnValue = ProspectConverted.checkIfProspectManagementWorkflow('4');
       });
 
       it('returns true', () => {
@@ -105,9 +99,7 @@ describe('ProspectConverted', () => {
 
     describe('when the case type category is not prospect', () => {
       beforeEach(() => {
-        returnValue = ProspectConverted.checkIfProspectingCaseTypeCategory({
-          'case_type_id.case_type_category': 1
-        });
+        returnValue = ProspectConverted.checkIfProspectManagementWorkflow('1');
       });
 
       it('returns false', () => {

--- a/ang/test/prospect/prospect-converted/services/prospect-converted.service.spec.js
+++ b/ang/test/prospect/prospect-converted/services/prospect-converted.service.spec.js
@@ -84,12 +84,12 @@ describe('ProspectConverted', () => {
     });
   });
 
-  describe('checkIfProspectManagementWorkflow()', () => {
+  describe('checkIfSalesOpportunityTrackingWorkflow()', () => {
     let returnValue;
 
-    describe('when the case type category is prospect', () => {
+    describe('when the case type category is sales opportunity type', () => {
       beforeEach(() => {
-        returnValue = ProspectConverted.checkIfProspectManagementWorkflow('4');
+        returnValue = ProspectConverted.checkIfSalesOpportunityTrackingWorkflow('4');
       });
 
       it('returns true', () => {
@@ -97,9 +97,9 @@ describe('ProspectConverted', () => {
       });
     });
 
-    describe('when the case type category is not prospect', () => {
+    describe('when the case type category is not sales opportunity type', () => {
       beforeEach(() => {
-        returnValue = ProspectConverted.checkIfProspectManagementWorkflow('1');
+        returnValue = ProspectConverted.checkIfSalesOpportunityTrackingWorkflow('1');
       });
 
       it('returns false', () => {


### PR DESCRIPTION
## Overview
As part of this PR, Case Category Instance Support has been added for Prospects. That means more Case Categories can be added of Prospect Type.

1. Added a new Instance called `Sales/Opportunity Tracking`.
2. Assigned existing `prospecting` category to this instance.
3. Created menu for Manage Workflows.

## Technical Details
Added a new upgrader `CRM/Prospect/Upgrader/Steps/Step1009.php`, which takes care of the features mentioned above.
Added other necessary helper classes like
`ProspectManagementUtils`
`AddManageWorkflowMenu``
`CaseCategoryInstanceSupport`

Refactored FE code, to reduce the number of API calls.

Made changes to the FE logic to support Instance.