### PR TITLE
RSE-1276: Update menu items setup to use singular labels

### DIFF
--- a/CRM/Prospect/Helper/CaseTypeCategory.php
+++ b/CRM/Prospect/Helper/CaseTypeCategory.php
@@ -5,8 +5,25 @@
  */
 class CRM_Prospect_Helper_CaseTypeCategory {
 
+  /**
+   * Prospect instance name.
+   */
   const PROSPECT_INSTANCE_NAME = 'sales_opportunity_tracking';
+
+  /**
+   * Prospect category name.
+   */
   const PROSPECT_CASE_TYPE_CATEGORY_NAME = 'Prospecting';
+
+  /**
+   * Prospect category label.
+   */
+  const PROSPECT_CASE_TYPE_CATEGORY_LABEL = 'Prospecting';
+
+  /**
+   * Prospect category singular label.
+   */
+  const PROSPECT_CASE_TYPE_CATEGORY_SINGULAR_LABEL = 'Prospecting';
 
   /**
    * Checks if Case Type ID/Name belongs to Prospect Category.
@@ -62,6 +79,20 @@ class CRM_Prospect_Helper_CaseTypeCategory {
     ]);
 
     return array_column($result['values'], 'title', 'id');
+  }
+
+  /**
+   * Get data for creating the menu.
+   *
+   * @return string[]
+   *   Category data.
+   */
+  public static function getDataForMenu() {
+    return [
+      'name' => self::PROSPECT_CASE_TYPE_CATEGORY_NAME,
+      'label' => self::PROSPECT_CASE_TYPE_CATEGORY_LABEL,
+      'singular_label' => self::PROSPECT_CASE_TYPE_CATEGORY_SINGULAR_LABEL,
+    ];
   }
 
 }

--- a/CRM/Prospect/Service/SalesOpportunityTrackingMenu.php
+++ b/CRM/Prospect/Service/SalesOpportunityTrackingMenu.php
@@ -11,7 +11,9 @@ class CRM_Prospect_Service_SalesOpportunityTrackingMenu extends CRM_Civicase_Ser
   /**
    * {@inheritDoc}
    */
-  public function getSubmenus($caseTypeCategoryName, array $permissions = NULL) {
+  public function getSubmenus(array $caseTypeCategory, array $permissions = NULL) {
+    $singularLabelForMenu = ucfirst(strtolower($caseTypeCategory['singular_label']));
+    $caseTypeCategoryName = $caseTypeCategory['name'];
     $labelForMenu = ucfirst(strtolower($caseTypeCategoryName));
     $categoryId = civicrm_api3('OptionValue', 'getsingle', [
       'option_group_id' => 'case_type_categories',
@@ -35,14 +37,14 @@ class CRM_Prospect_Service_SalesOpportunityTrackingMenu extends CRM_Civicase_Ser
         'permission_operator' => 'OR',
       ],
       [
-        'label' => ts("New {$labelForMenu}"),
+        'label' => ts('New %1', ['1' => $singularLabelForMenu]),
         'name' => "new_{$caseTypeCategoryName}",
         'url' => 'civicrm/case/add?case_type_category=' . $categoryId . '&action=add&reset=1&context=standalone',
         'permission' => "{$permissions['ADD_CASE_CATEGORY']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
         'permission_operator' => 'OR',
       ],
       [
-        'label' => ts("Manage {$labelForMenu}"),
+        'label' => ts('Manage %1', ['1' => $labelForMenu]),
         'name' => "manage_{$caseTypeCategoryName}",
         'url' => 'civicrm/case/a/?case_type_category=' . $categoryId . '#/case/list?cf=%7B"case_type_category":"' . $categoryId . '"%7D',
         'permission' => "{$permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
@@ -50,7 +52,7 @@ class CRM_Prospect_Service_SalesOpportunityTrackingMenu extends CRM_Civicase_Ser
         'has_separator' => 1,
       ],
       [
-        'label' => ts("Manage Workflows"),
+        'label' => ts('Manage %1 Types', ['1' => $singularLabelForMenu]),
         'name' => "manage_{$caseTypeCategoryName}_workflows",
         'url' => 'civicrm/workflow/a?case_type_category=' . $categoryId . '&p=al#/list',
         'permission' => "{$permissions['ADMINISTER_CASE_CATEGORY']['name']}, administer CiviCRM",

--- a/CRM/Prospect/Setup/CreateProspectMenus.php
+++ b/CRM/Prospect/Setup/CreateProspectMenus.php
@@ -12,7 +12,7 @@ class CRM_Prospect_Setup_CreateProspectMenus {
    * Creates the Prospect menu items.
    */
   public function apply() {
-    (new SalesOpportunityTrackingMenu())->createItems(CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME);
+    (new SalesOpportunityTrackingMenu())->createItems(CaseTypeCategoryHelper::getDataForMenu());
   }
 
 }

--- a/CRM/Prospect/Upgrader/Steps/Step1008.php
+++ b/CRM/Prospect/Upgrader/Steps/Step1008.php
@@ -15,7 +15,7 @@ class CRM_Prospect_Upgrader_Steps_Step1008 {
    */
   public function apply() {
     (new SalesOpportunityTrackingMenu())->resetCaseCategorySubmenusUrl(
-        CRM_Prospect_Helper_CaseTypeCategory::PROSPECT_CASE_TYPE_CATEGORY_NAME
+        CRM_Prospect_Helper_CaseTypeCategory::getDataForMenu()
     );
 
     CRM_Core_BAO_Navigation::resetNavigation();


### PR DESCRIPTION
## Overview
This PR updates the menu setup code because of changes done in https://github.com/compucorp/uk.co.compucorp.civicase/pull/760 

## Before & After
This does not change anything visually, only the code is updated so it follows the changes done in https://github.com/compucorp/uk.co.compucorp.civicase/pull/760

## Technical Details

`SalesOpportunityTrackingMenu`  class  extends `CRM_Civicase_Service_CaseCategoryMenu` and this class was updated to accept the name, label, and singular label to use when creating case category menu items. We now pass the missing arguments.