### PR TITLE
GSSPRT-123: Unlink Contribution Action

### DIFF
--- a/ang/prospect/app.config.js
+++ b/ang/prospect/app.config.js
@@ -36,6 +36,12 @@
           action: 'ViewPledgeContribution',
           type: 'contribution',
           icon: 'fa-list'
+        },
+        {
+          title: 'Unlink Contribution',
+          action: 'UnlinkContribution',
+          type: 'contribution',
+          icon: 'fa-ban'
         }
       ];
     }

--- a/ang/prospect/case-actions/services/unlink-contribution-case-action.service.js
+++ b/ang/prospect/case-actions/services/unlink-contribution-case-action.service.js
@@ -22,9 +22,12 @@
       var isContributeTypeProspect =
         cases[0].prospect.paymentInfo.payment_entity === 'contribute';
 
-      return cases[0] &&
-        ProspectConverted.checkIfSalesOpportunityTrackingWorkflow(cases[0]['case_type_id.case_type_category']) &&
-        cases[0].prospect.isProspectConverted && isContributeTypeProspect;
+      if (!isContributeTypeProspect) {
+        return;
+      }
+
+      return ProspectConverted.checkIfSalesOpportunityTrackingWorkflow(cases[0]['case_type_id.case_type_category']) &&
+        cases[0].prospect.isProspectConverted;
     };
 
     /**

--- a/ang/prospect/case-actions/services/unlink-contribution-case-action.service.js
+++ b/ang/prospect/case-actions/services/unlink-contribution-case-action.service.js
@@ -1,0 +1,52 @@
+(function (angular) {
+  var module = angular.module('prospect');
+
+  module.service('UnlinkContributionCaseAction', UnlinkContributionCaseAction);
+
+  /**
+   * @param {object} ProspectConverted Prospect Converted Service
+   */
+  function UnlinkContributionCaseAction (ProspectConverted) {
+    /**
+     * Checks if the Action is allowed
+     *
+     * @param {object} action action
+     * @param {Array} cases cases
+     * @returns {boolean} if action is allowed
+     */
+    this.isActionAllowed = function (action, cases) {
+      if (!cases[0] || !cases[0].prospect.paymentInfo) {
+        return;
+      }
+
+      var isContributeTypeProspect =
+        cases[0].prospect.paymentInfo.payment_entity === 'contribute';
+
+      return cases[0] &&
+        ProspectConverted.checkIfSalesOpportunityTrackingWorkflow(cases[0]['case_type_id.case_type_category']) &&
+        cases[0].prospect.isProspectConverted && isContributeTypeProspect;
+    };
+
+    /**
+     * Click event handler for the Action
+     *
+     * @param {Array} cases cases
+     * @param {object} action action
+     * @param {Function} callbackFn call back function
+     */
+    this.doAction = function (cases, action, callbackFn) {
+      var prospectID = cases[0].prospect.id;
+      var contributionId = cases[0].prospect.paymentInfo.payment_entity_id;
+
+      CRM.confirm({ title: action.title, message: 'Are you sure?' })
+        .on('crmConfirm:yes', function () {
+          var calls = [
+            ['ProspectConverted', 'delete', { id: prospectID }],
+            ['Contribution', 'create', { id: contributionId, contribution_status_id: 'Cancelled' }]
+          ];
+
+          callbackFn(calls);
+        });
+    };
+  }
+})(angular);

--- a/ang/prospect/prospect-converted/decorators/case-details.decorators.js
+++ b/ang/prospect/prospect-converted/decorators/case-details.decorators.js
@@ -27,13 +27,14 @@
 
           var caseID = $scope.item.id;
 
-          ProspectConverted.getProspectIsConverted(caseID)
-            .then(function (isConverted) {
-              if (!isConverted) {
+          ProspectConverted.getProspectConvertedValue(caseID)
+            .then(function (prospectConverted) {
+              if (!prospectConverted) {
                 return;
               }
 
-              $scope.item.prospect.isProspectConverted = isConverted;
+              $scope.item.prospect.isProspectConverted = !!prospectConverted;
+              $scope.item.prospect.id = prospectConverted.id;
 
               ProspectConverted.getPaymentInfo(caseID)
                 .then(addExtraProspectField);

--- a/ang/prospect/prospect-converted/services/prospect-converted.service.js
+++ b/ang/prospect/prospect-converted/services/prospect-converted.service.js
@@ -12,7 +12,7 @@
    */
   function ProspectConverted (crmApi, ProspectGlobalValues, CaseTypeCategory) {
     /**
-     * Returns if the prospect converted value
+     * Returns the prospect converted value
      *
      * @param {string} caseID case id
      * @returns {Promise} promise

--- a/ang/prospect/prospect-converted/services/prospect-converted.service.js
+++ b/ang/prospect/prospect-converted/services/prospect-converted.service.js
@@ -12,17 +12,17 @@
    */
   function ProspectConverted (crmApi, ProspectGlobalValues, CaseTypeCategory) {
     /**
-     * Returns if the case is converted to Prospect
+     * Returns if the prospect converted value
      *
      * @param {string} caseID case id
      * @returns {Promise} promise
      */
-    this.getProspectIsConverted = function (caseID) {
+    this.getProspectConvertedValue = function (caseID) {
       return crmApi('ProspectConverted', 'get', {
         sequential: 1,
         prospect_case_id: caseID
-      }).then(function (caseData) {
-        return caseData.count > 0;
+      }).then(function (prospect) {
+        return prospect.values[0];
       });
     };
 

--- a/ang/test/prospect/case-actions/services/unlink-contribution-case-action.service.spec.js
+++ b/ang/test/prospect/case-actions/services/unlink-contribution-case-action.service.spec.js
@@ -54,7 +54,7 @@ describe('UnlinkContributionCaseAction', () => {
         });
 
         it('hides the action', () => {
-          expect(returnValue).toBe(false);
+          expect(returnValue).toBeFalsy();
         });
       });
     });

--- a/ang/test/prospect/case-actions/services/unlink-contribution-case-action.service.spec.js
+++ b/ang/test/prospect/case-actions/services/unlink-contribution-case-action.service.spec.js
@@ -1,0 +1,133 @@
+/* eslint-env jasmine */
+
+describe('UnlinkContributionCaseAction', () => {
+  let ProspectConverted, UnlinkContributionCaseAction;
+
+  beforeEach(module('crmUtil', 'prospect', 'prospect.data'));
+
+  beforeEach(inject((_ProspectConverted_, _UnlinkContributionCaseAction_) => {
+    ProspectConverted = _ProspectConverted_;
+    UnlinkContributionCaseAction = _UnlinkContributionCaseAction_;
+
+    spyOn(ProspectConverted, 'checkIfSalesOpportunityTrackingWorkflow');
+  }));
+
+  describe('visibility', () => {
+    describe('when the case is of sales opportunity type', () => {
+      describe('when prospect is converted to contribution', () => {
+        var returnValue;
+
+        beforeEach(() => {
+          var cases = [{
+            prospect: {
+              isProspectConverted: true,
+              paymentInfo: {
+                payment_entity: 'contribute'
+              }
+            }
+          }];
+
+          ProspectConverted.checkIfSalesOpportunityTrackingWorkflow.and.returnValue(true);
+          returnValue = UnlinkContributionCaseAction.isActionAllowed({}, cases);
+        });
+
+        it('shows the action', () => {
+          expect(returnValue).toBe(true);
+        });
+      });
+
+      describe('when prospect is not converted to contribution', () => {
+        var returnValue;
+
+        beforeEach(() => {
+          var cases = [{
+            prospect: {
+              isProspectConverted: true,
+              paymentInfo: {
+                payment_entity: 'not contribute'
+              }
+            }
+          }];
+
+          ProspectConverted.checkIfSalesOpportunityTrackingWorkflow.and.returnValue(true);
+          returnValue = UnlinkContributionCaseAction.isActionAllowed({}, cases);
+        });
+
+        it('hides the action', () => {
+          expect(returnValue).toBe(false);
+        });
+      });
+    });
+
+    describe('when the case is NOT of sales opportunity type', () => {
+      var returnValue;
+
+      beforeEach(() => {
+        var cases = [{
+          prospect: {
+            isProspectConverted: true,
+            paymentInfo: {
+              payment_entity: 'contribute'
+            }
+          }
+        }];
+
+        ProspectConverted.checkIfSalesOpportunityTrackingWorkflow.and.returnValue(false);
+        returnValue = UnlinkContributionCaseAction.isActionAllowed({}, cases);
+      });
+
+      it('hides the action', () => {
+        expect(returnValue).toBe(false);
+      });
+    });
+  });
+
+  describe('click handler', () => {
+    let crmConfirmOnFn, crmConfirmCallbackFn, mockCallbackFn;
+
+    beforeEach(() => {
+      crmConfirmOnFn = jasmine.createSpy('crmConfirmOnFn').and.callFake(function (evtName, crmConfirmCallbackFntn) {
+        crmConfirmCallbackFn = crmConfirmCallbackFntn;
+      });
+
+      spyOn(CRM, 'confirm');
+      CRM.confirm.and.returnValue({ on: crmConfirmOnFn });
+    });
+
+    beforeEach(() => {
+      var cases = [{
+        prospect: {
+          id: '1',
+          isProspectConverted: true,
+          paymentInfo: {
+            payment_entity: 'contribute',
+            payment_entity_id: '2'
+          }
+        }
+      }];
+
+      mockCallbackFn = jasmine.createSpy('mockCallbackFn');
+      UnlinkContributionCaseAction.doAction(cases, { title: 'Unlink Contribution' }, mockCallbackFn);
+    });
+
+    it('confirms before unlinking', () => {
+      expect(CRM.confirm).toHaveBeenCalledWith({
+        title: 'Unlink Contribution',
+        message: 'Are you sure?'
+      });
+    });
+
+    describe('when unlinking is confirmed', () => {
+      beforeEach(() => {
+        crmConfirmCallbackFn();
+      });
+
+      it('unlinks the contribution', () => {
+        expect(mockCallbackFn).toHaveBeenCalledWith([
+          ['ProspectConverted', 'delete', { id: '1' }],
+          ['Contribution', 'create', { id: '2', contribution_status_id: 'Cancelled' }]
+        ]);
+      });
+    });
+  });
+});

--- a/ang/test/prospect/prospect-converted/services/prospect-converted.service.spec.js
+++ b/ang/test/prospect/prospect-converted/services/prospect-converted.service.spec.js
@@ -2,9 +2,12 @@
 
 describe('ProspectConverted', () => {
   let crmApi, $q, $rootScope, PaymentInfoData, ProspectConverted,
-    ProspectConvertedData;
+    ProspectConvertedData, crmApiMock;
 
-  beforeEach(module('crmUtil', 'prospect', 'prospect.data'));
+  beforeEach(module('crmUtil', 'prospect', 'prospect.data', function ($provide) {
+    crmApiMock = jasmine.createSpy('crmApi');
+    $provide.value('crmApi', crmApiMock);
+  }));
 
   beforeEach(inject((_$q_, _ProspectConverted_, _crmApi_,
     _ProspectConvertedData_, _$rootScope_, _PaymentInfo_) => {
@@ -16,15 +19,15 @@ describe('ProspectConverted', () => {
     crmApi = _crmApi_;
   }));
 
-  describe('getProspectIsConverted()', () => {
+  describe('getProspectConvertedValue()', () => {
     const caseID = '1';
 
     describe('when case is already converted to prospect', () => {
-      let getProspectIsConvertedPromise;
+      let getProspectConvertedValuePromise;
 
       beforeEach(() => {
-        crmApi.and.returnValue($q.resolve(ProspectConvertedData));
-        getProspectIsConvertedPromise = ProspectConverted.getProspectIsConverted(caseID);
+        crmApiMock.and.returnValue($q.resolve(ProspectConvertedData));
+        getProspectConvertedValuePromise = ProspectConverted.getProspectConvertedValue(caseID);
       });
 
       it('calls ProspectConverted API', () => {
@@ -34,27 +37,27 @@ describe('ProspectConverted', () => {
         });
       });
 
-      it('resolved the promise with a true value', () => {
-        getProspectIsConvertedPromise.then((returnValue) => {
-          expect(returnValue).toBe(true);
+      it('resolved the promise with the found prospects', () => {
+        getProspectConvertedValuePromise.then((returnValue) => {
+          expect(returnValue).toBe(ProspectConvertedData.values[0]);
         });
         $rootScope.$digest();
       });
     });
 
     describe('when case is NOT already converted to prospect', () => {
-      let getProspectIsConvertedPromise;
+      let getProspectConvertedValuePromise;
 
       beforeEach(() => {
-        crmApi.and.returnValue($q.resolve({
+        crmApiMock.and.returnValue($q.resolve({
           count: 0, values: []
         }));
-        getProspectIsConvertedPromise = ProspectConverted.getProspectIsConverted(caseID);
+        getProspectConvertedValuePromise = ProspectConverted.getProspectConvertedValue(caseID);
       });
 
-      it('resolved the promise with a false value', () => {
-        getProspectIsConvertedPromise.then((returnValue) => {
-          expect(returnValue).toBe(false);
+      it('resolved the promise with a empty list', () => {
+        getProspectConvertedValuePromise.then((returnValue) => {
+          expect(returnValue).toBeUndefined();
         });
         $rootScope.$digest();
       });

--- a/prospect.php
+++ b/prospect.php
@@ -14,6 +14,7 @@ require_once 'prospect.civix.php';
  */
 function prospect_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
   $permissions['prospect_converted']['get'] = ['access CiviCRM'];
+  $permissions['prospect_converted']['delete'] = ['administer CiviProspecting'];
 }
 
 /**


### PR DESCRIPTION
## Overview
As part of this PR, a new Case action "Unlink Contribution" has been added. It is shown only when the Prospect is converted to `contribution`. This action, moves the contribution to "cancelled" status, and also unlinks the contribution from the prospect.

## Before
No such action was present.

## After
![2021-05-27 at 11 22 AM](https://user-images.githubusercontent.com/5058867/119773133-cf4e5800-bedd-11eb-96fb-acf20c8fe66a.png)

## Technical Details
In `ang/prospect/app.config.js`, added the new action.
Added `ang/prospect/case-actions/services/unlink-contribution-case-action.service.js` service, to control the visibility of the action.
