### PR TITLE
GSSPRT-132: Add Unlink Contribution Action button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,3 +24,7 @@ div.prospect-pledge-payment-wrapper div.restriction-code {
   display: inline;
   margin-left: 12px;
 }
+
+a.contribution-unlink {
+  cursor: pointer;
+}

--- a/info.xml
+++ b/info.xml
@@ -15,8 +15,8 @@
     <url desc="Support">https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/blob/master/readme.md</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2019-07-04</releaseDate>
-  <version>1.2.1</version>
+  <releaseDate>2021-06-14</releaseDate>
+  <version>1.2.2</version>
   <develStage></develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/js/Prospect.Page.CaseView.js
+++ b/js/Prospect.Page.CaseView.js
@@ -6,6 +6,7 @@ CRM.Prospect.Page.CaseView = (function($) {
     this._alignProspectFinancialInformationCustomFieldsTable();
     this._setupExpectedDateInput();
     this._bindProspectConvertAction();
+    this._bindUnlinkContributionAction();
     this._hideDuplicateFinancialInformationFields();
     this._bindExpectationUpdate();
     this._bindExpectedDateUpdate();
@@ -86,6 +87,23 @@ CRM.Prospect.Page.CaseView = (function($) {
 
     $('select.prospect-convert').change(function() {
       that._convertProspect($(this).data('contact-id'), $(this).val());
+    });
+  };
+
+  CaseView.prototype._bindUnlinkContributionAction = function() {
+    $('.contribution-unlink').click(function(e) {
+      CRM.confirm({message: 'Are you sure?' })
+        .on('crmConfirm:yes', function() {
+          var prospectID = $('.contribution-unlink').data('prospect-id');
+          var contributionId = $('.contribution-unlink').data('contribution-id');
+
+          CRM.api3([
+            ['ProspectConverted', 'delete', { id: prospectID }],
+            ['Contribution', 'create', { id: contributionId, contribution_status_id: 'Cancelled' }]
+          ]).then(function () {
+            location.reload();
+          });
+        });
     });
   };
 

--- a/prospect.php
+++ b/prospect.php
@@ -336,6 +336,7 @@ function prospect_civicrm_alterTemplateFile($formName, &$form, $context, &$tplNa
  * @param string $tplName
  */
 function _prospect_civicrm_alterTemplateFile_CRM_Case_Page_Tab($formName, &$form, $context, &$tplName) {
+  _prospect_civicrm_addMainCSSFile();
   $caseId = CRM_Utils_Request::retrieve('id', 'Integer');
 
   if (empty($caseId)) {
@@ -350,6 +351,7 @@ function _prospect_civicrm_alterTemplateFile_CRM_Case_Page_Tab($formName, &$form
   }
 
   $form->assign('isCaseConverted', !empty($prospectConverted));
+  $form->assign('prospectID', $prospectConverted->id);
   $form->assign('prospectFinancialInformationFields', $fields);
   $form->assign('campaignLabel', _prospect_civicrm_get_campaign_label_by_id($fields->getValueOf('Campaign_Id')));
   $form->assign('currency', CRM_Core_BAO_Country::getDefaultCurrencySymbol());

--- a/prospect.php
+++ b/prospect.php
@@ -122,6 +122,13 @@ function prospect_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
   _prospect_civix_civicrm_alterSettingsFolders($metaDataFolders);
 }
 
+/**
+ * Implements hook_civicrm_alterAPIPermissions().
+ */
+function prospect_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
+  $permissions['prospect_converted']['delete'] = ['administer CiviCase'];
+}
+
 // --- Functions below this ship commented out. Uncomment as required. ---
 
 /**

--- a/prospect.php
+++ b/prospect.php
@@ -483,9 +483,13 @@ function prospect_civicrm_buildForm($formName, &$form) {
  * Implements hook_civicrm_fieldOptions().
  */
 function prospect_civicrm_fieldOptions($entity, $field, &$options, $params) {
+  if ($entity !== 'Case') {
+    return;
+  }
+
   $campaignCustomFieldID = CRM_Core_BAO_CustomField::getCustomFieldID('Campaign', 'Prospect_Financial_Information');
 
-  if ($entity === 'Case' && $field === 'custom_' . $campaignCustomFieldID) {
+  if ($field === 'custom_' . $campaignCustomFieldID) {
     $options = _prospect_civicrm_get_campaign_options();
   }
 }

--- a/templates/CRM/Case/Page/Tab.extra.tpl
+++ b/templates/CRM/Case/Page/Tab.extra.tpl
@@ -62,6 +62,15 @@
               {/if}
               <div class="payment-link">
                 <a class="action-item" href="{$paymentInfo.payment_url}&cid={$contactId}">{ts}View {if $paymentInfo.payment_entity == 'pledge'}Pledge{elseif $paymentInfo.payment_entity == 'contribute'}Contribution{/if}{/ts}</a>
+                {if $paymentInfo.payment_entity == 'contribute'}
+                <br>
+                <a
+                  class="action-item contribution-unlink btn"
+                  data-contribution-id="{$paymentInfo.payment_entity_id}"
+                  data-prospect-id="{$prospectID}">
+                  {ts}Unlink Contribution{/ts}
+                </a>
+                {/if}
               </div>
             </div>
           {/if}

--- a/templates/CRM/Case/Page/Tab.extra.tpl
+++ b/templates/CRM/Case/Page/Tab.extra.tpl
@@ -65,7 +65,7 @@
                 {if $paymentInfo.payment_entity == 'contribute'}
                 <br>
                 <a
-                  class="action-item contribution-unlink btn"
+                  class="action-item contribution-unlink"
                   data-contribution-id="{$paymentInfo.payment_entity_id}"
                   data-prospect-id="{$prospectID}">
                   {ts}Unlink Contribution{/ts}


### PR DESCRIPTION
## Overview
This PR is related to https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/pull/84.
One of the clients(Greenhouse), uses CiviProspect v1.2.1, which is not compatible with latest prospect code. Hence this PR fixes the same issue, for an older tag(1.2.1).

## Before
The "Unlink Contribution" button did not exist.

## After
![after](https://user-images.githubusercontent.com/5058867/121900767-696a2900-cd43-11eb-8de1-aecfc69fb30f.gif)
