### PR TITLE
GSSPRT-132: Fix permissions(for CiviProspect v1.x)

### DIFF
--- a/prospect.php
+++ b/prospect.php
@@ -354,7 +354,13 @@ function _prospect_civicrm_alterTemplateFile_CRM_Case_Page_Tab($formName, &$form
   $prospectConverted = CRM_Prospect_BAO_ProspectConverted::findByCaseID($caseId);
 
   if (!empty($prospectConverted)) {
-    $form->assign('paymentInfo', $prospectConverted->getPaymentInfo());
+    $paymentInfo = $prospectConverted->getPaymentInfo();
+    $form->assign('paymentInfo', $paymentInfo);
+
+    if (CRM_Core_Permission::check(['administer CiviCase']) &&
+      $paymentInfo['payment_entity'] == 'contribute') {
+      $form->assign('showUnlinkContributionButton', true);
+    }
   }
 
   $form->assign('isCaseConverted', !empty($prospectConverted));

--- a/templates/CRM/Case/Page/Tab.extra.tpl
+++ b/templates/CRM/Case/Page/Tab.extra.tpl
@@ -62,7 +62,7 @@
               {/if}
               <div class="payment-link">
                 <a class="action-item" href="{$paymentInfo.payment_url}&cid={$contactId}">{ts}View {if $paymentInfo.payment_entity == 'pledge'}Pledge{elseif $paymentInfo.payment_entity == 'contribute'}Contribution{/if}{/ts}</a>
-                {if $paymentInfo.payment_entity == 'contribute'}
+                {if $showUnlinkContributionButton}
                 <br>
                 <a
                   class="action-item contribution-unlink"


### PR DESCRIPTION
## Overview
The "Unlink Contribution" was shown, even when "administer CiviCase" permission was not present. This PR fixes the same.
This PR is related to https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/pull/89

## Before
The "Unlink Contribution" was shown, even when "administer CiviCase" permission was not present.

## After
The "Unlink Contribution" is hidden, when "administer CiviCase" permission is not present.
