### PR TITLE
CPS-656: Fix permissions(for CiviProspect v2.x)

### DIFF
--- a/ang/prospect.ang.php
+++ b/ang/prospect.ang.php
@@ -10,6 +10,8 @@
 
 use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
 
+expose_prospect_permissions();
+
 /**
  * Get a list of JS files.
  */
@@ -21,6 +23,16 @@ function get_prospect_js_files() {
       'ang/prospect/*.js'
     )
   );
+}
+
+/**
+ * Expose permissions to frontend.
+ */
+function expose_prospect_permissions() {
+  Civi::resources()
+    ->addPermissions([
+      'administer CiviProspecting',
+    ]);
 }
 
 return [

--- a/ang/prospect/case-actions/services/unlink-contribution-case-action.service.js
+++ b/ang/prospect/case-actions/services/unlink-contribution-case-action.service.js
@@ -26,7 +26,8 @@
         return;
       }
 
-      return ProspectConverted.checkIfSalesOpportunityTrackingWorkflow(cases[0]['case_type_id.case_type_category']) &&
+      return CRM.checkPerm('administer CiviProspecting') &&
+        ProspectConverted.checkIfSalesOpportunityTrackingWorkflow(cases[0]['case_type_id.case_type_category']) &&
         cases[0].prospect.isProspectConverted;
     };
 

--- a/ang/test/prospect/case-actions/services/unlink-contribution-case-action.service.spec.js
+++ b/ang/test/prospect/case-actions/services/unlink-contribution-case-action.service.spec.js
@@ -9,12 +9,61 @@ describe('UnlinkContributionCaseAction', () => {
     ProspectConverted = _ProspectConverted_;
     UnlinkContributionCaseAction = _UnlinkContributionCaseAction_;
 
+    CRM.checkPerm = jasmine.createSpy('checkPerm');
+    CRM.checkPerm.and.returnValue(true);
+
     spyOn(ProspectConverted, 'checkIfSalesOpportunityTrackingWorkflow');
   }));
 
   describe('visibility', () => {
     describe('when the case is of sales opportunity type', () => {
-      describe('when prospect is converted to contribution', () => {
+      describe('when "administer CiviProspecting" permission is present', () => {
+        describe('when prospect is converted to contribution', () => {
+          var returnValue;
+
+          beforeEach(() => {
+            var cases = [{
+              prospect: {
+                isProspectConverted: true,
+                paymentInfo: {
+                  payment_entity: 'contribute'
+                }
+              }
+            }];
+
+            ProspectConverted.checkIfSalesOpportunityTrackingWorkflow.and.returnValue(true);
+            returnValue = UnlinkContributionCaseAction.isActionAllowed({}, cases);
+          });
+
+          it('shows the action', () => {
+            expect(returnValue).toBe(true);
+          });
+        });
+
+        describe('when prospect is not converted to contribution', () => {
+          var returnValue;
+
+          beforeEach(() => {
+            var cases = [{
+              prospect: {
+                isProspectConverted: true,
+                paymentInfo: {
+                  payment_entity: 'not contribute'
+                }
+              }
+            }];
+
+            ProspectConverted.checkIfSalesOpportunityTrackingWorkflow.and.returnValue(true);
+            returnValue = UnlinkContributionCaseAction.isActionAllowed({}, cases);
+          });
+
+          it('hides the action', () => {
+            expect(returnValue).toBeFalsy();
+          });
+        });
+      });
+
+      describe('when "administer CiviProspecting" permission is NOT present', () => {
         var returnValue;
 
         beforeEach(() => {
@@ -27,34 +76,14 @@ describe('UnlinkContributionCaseAction', () => {
             }
           }];
 
-          ProspectConverted.checkIfSalesOpportunityTrackingWorkflow.and.returnValue(true);
+          CRM.checkPerm.and.returnValue(false);
+
           returnValue = UnlinkContributionCaseAction.isActionAllowed({}, cases);
-        });
-
-        it('shows the action', () => {
-          expect(returnValue).toBe(true);
-        });
-      });
-
-      describe('when prospect is not converted to contribution', () => {
-        var returnValue;
-
-        beforeEach(() => {
-          var cases = [{
-            prospect: {
-              isProspectConverted: true,
-              paymentInfo: {
-                payment_entity: 'not contribute'
-              }
-            }
-          }];
-
           ProspectConverted.checkIfSalesOpportunityTrackingWorkflow.and.returnValue(true);
-          returnValue = UnlinkContributionCaseAction.isActionAllowed({}, cases);
         });
 
         it('hides the action', () => {
-          expect(returnValue).toBeFalsy();
+          expect(returnValue).toBe(false);
         });
       });
     });


### PR DESCRIPTION
## Overview
The "Unlink Contribution" was shown, even when "administer CiviProspecting" permission was not present. This PR fixes the same.

## Before
The "Unlink Contribution" was shown, even when "administer CiviProspecting" permission was not present.

## After
The "Unlink Contribution" is hidden, when "administer CiviProspecting" permission is not present.
