### PR TITLE
CPS-655: Fix new site deployments

### DIFF
--- a/CRM/Prospect/Setup/CaseCategoryInstanceSupport.php
+++ b/CRM/Prospect/Setup/CaseCategoryInstanceSupport.php
@@ -50,7 +50,7 @@ class CRM_Prospect_Setup_CaseCategoryInstanceSupport {
       'name' => CaseTypeCategoryHelper::PROSPECT_CASE_TYPE_CATEGORY_NAME,
     ])['values'][0];
 
-    CaseCategoryInstance::createInstanceTypeFor(
+    (new CaseCategoryInstance())->createInstanceTypeFor(
       $prospectCaseTypeCategory['value'],
       $prospectInstanceId
     );

--- a/CRM/Prospect/Upgrader.php
+++ b/CRM/Prospect/Upgrader.php
@@ -11,6 +11,9 @@ use CRM_Prospect_Setup_AddProspectCategoryWordReplacement as AddProspectCategory
 use CRM_Prospect_Setup_EnableRequiredComponents as EnableRequiredComponents;
 use CRM_Prospect_Uninstall_DeleteInstalledCustomGroups as DeleteInstalledCustomGroups;
 use CRM_Prospect_Uninstall_DeleteProspectMenus as DeleteProspectMenus;
+use CRM_Prospect_Setup_CaseCategoryInstanceSupport as CaseCategoryInstanceSupport;
+use CRM_Prospect_Setup_AddManageWorkflowMenu as AddManageWorkflowMenu;
+use CRM_Civicase_Setup_AddSingularLabels as AddSingularLabels;
 
 /**
  * Collection of upgrade steps.
@@ -54,6 +57,9 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
       new ProcessProspectCategoryForCustomGroupSupport(),
       new CreateProspectWorkflowCaseType(),
       new MoveCustomFieldsToWorkFlowCaseType(),
+      new CaseCategoryInstanceSupport(),
+      new AddManageWorkflowMenu(),
+      new AddSingularLabels(),
     ];
 
     foreach ($steps as $step) {


### PR DESCRIPTION
## Overview
Some of the recently added upgrader logic was not applied when creating a new fresh site. This PR fixes the same.

## Before
Singular Labels were not created.
Case Category Instance support was not present.
Manage workflow menus were not created.

## After
Singular Labels are created.
Case Category Instance support is present.
Manage workflow menus are created.