### PR TITLE
MAE-824: Fix failing installation caused by the early use of column separator

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -28,7 +28,7 @@ jobs:
       run: git fetch -n origin ${GITHUB_BASE_REF}
 
     - name: Run phpcs linter
-      run: git diff --diff-filter=d origin/${GITHUB_BASE_REF} --name-only -- '*.php' | xargs -r ./bin/phpcs.phar --standard=phpcs-ruleset.xml
+      run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' | xargs -r ./bin/phpcs.phar --standard=phpcs-ruleset.xml
 
     - name: Run stylelint linter
       #This step will always run regardless of previous step's status

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,18 +13,22 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Read .nvmrc
+      run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+      id: nvm
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '${{ steps.nvm.outputs.NVMRC }}'
+
     - name: Run npm install
-      shell: bash -l {0}
-      run: |
-        nvm install
-        nvm use
-        npm i
+      run: npm i
 
     - name: Fetch target branch
       run: git fetch -n origin ${GITHUB_BASE_REF}
 
     - name: Run phpcs linter
-      run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' | xargs -r ./bin/phpcs.phar --standard=phpcs-ruleset.xml
+      run: git diff --diff-filter=d origin/${GITHUB_BASE_REF} --name-only -- '*.php' | xargs -r ./bin/phpcs.phar --standard=phpcs-ruleset.xml
 
     - name: Run stylelint linter
       #This step will always run regardless of previous step's status

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.1.0-php7.2-chrome
+    container: compucorp/civicrm-buildkit:1.1.1-php7.2-chrome
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -40,6 +40,7 @@ jobs:
       - name: Download CiviProspect dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
+          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.usermenu.git
           git clone --depth 1 https://github.com/civicrm/org.civicrm.shoreditch.git
           git clone --depth 1 --no-single-branch https://github.com/compucorp/uk.co.compucorp.civicase.git
 
@@ -58,7 +59,7 @@ jobs:
       - name: Install CiviProspect and its dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          cv en shoreditch civicase
+          cv en usermenu shoreditch civicase
           cv en uk.co.compucorp.civicrm.prospect
 
       - name: Run JS unit tests

--- a/CRM/Prospect/Setup/MoveCustomFieldsToWorkFlowCaseType.php
+++ b/CRM/Prospect/Setup/MoveCustomFieldsToWorkFlowCaseType.php
@@ -26,10 +26,7 @@ class CRM_Prospect_Setup_MoveCustomFieldsToWorkFlowCaseType {
 
     $workflowCaseType = $this->getProspectWorkFlowCaseType();
     foreach ($result['values'] as $value) {
-      civicrm_api3('CustomGroup', 'create', [
-        'id' => $value['id'],
-        'extends_entity_column_value' => CRM_Core_DAO::VALUE_SEPARATOR . $workflowCaseType['id'] . CRM_Core_DAO::VALUE_SEPARATOR,
-      ]);
+      $this->updateCustomGroup($value['id'], (array) $workflowCaseType['id']);
     }
   }
 
@@ -45,6 +42,26 @@ class CRM_Prospect_Setup_MoveCustomFieldsToWorkFlowCaseType {
     ]);
 
     return $result;
+  }
+
+  /**
+   * Updates a custom group.
+   *
+   * We are using the custom group object here rather than the API because if
+   * this is updated via the API the `extends_entity_column_value` field will be
+   * validated against the extends_entity_column_id column.
+   *
+   * @param int $id
+   *   Custom group Id.
+   * @param array|null $entityColumnValues
+   *   Entity custom values for custom group.
+   */
+  protected function updateCustomGroup($id, $entityColumnValues) {
+    $cusGroup = new CRM_Core_BAO_CustomGroup();
+    $cusGroup->id = $id;
+    $entityColValue = is_null($entityColumnValues) ? 'null' : CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $entityColumnValues) . CRM_Core_DAO::VALUE_SEPARATOR;
+    $cusGroup->extends_entity_column_value = $entityColValue;
+    $cusGroup->save();
   }
 
 }

--- a/CRM/Prospect/Setup/MoveCustomFieldsToWorkFlowCaseType.php
+++ b/CRM/Prospect/Setup/MoveCustomFieldsToWorkFlowCaseType.php
@@ -57,11 +57,11 @@ class CRM_Prospect_Setup_MoveCustomFieldsToWorkFlowCaseType {
    *   Entity custom values for custom group.
    */
   protected function updateCustomGroup($id, $entityColumnValues) {
-    $cusGroup = new CRM_Core_BAO_CustomGroup();
-    $cusGroup->id = $id;
+    $customGroup = new CRM_Core_BAO_CustomGroup();
+    $customGroup->id = $id;
     $entityColValue = is_null($entityColumnValues) ? 'null' : CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $entityColumnValues) . CRM_Core_DAO::VALUE_SEPARATOR;
-    $cusGroup->extends_entity_column_value = $entityColValue;
-    $cusGroup->save();
+    $customGroup->extends_entity_column_value = $entityColValue;
+    $customGroup->save();
   }
 
 }

--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -8,7 +8,15 @@ fi
 # Give executable permission to PHPCS
 chmod +x phpcs.phar
 
-# Clone Drupal Coder repo
+# Download PHPCBF if it already does not exist
+if [ ! -f phpcbf.phar ]; then
+  curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar
+fi
+
+# Give executable permission to PHPCBF
+chmod +x phpcbf.phar
+
+# Clone CiviCRM Coder repo
 if [ ! -d drupal/coder ]; then
-  git clone --depth 1 --branch 8.3.13 https://git.drupalcode.org/project/coder.git drupal/coder
+  git clone --depth 1 https://github.com/civicrm/coder.git civicrm/coder
 fi

--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -9,6 +9,6 @@ fi
 chmod +x phpcs.phar
 
 # Clone Drupal Coder repo
-if [ ! -d civicrm/coder ]; then
-  git clone --depth 1 https://github.com/civicrm/coder.git civicrm/coder
+if [ ! -d drupal/coder ]; then
+  git clone --depth 1 --branch 8.3.13 https://git.drupalcode.org/project/coder.git drupal/coder
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1352,8 +1352,8 @@
       }
     },
     "civicrm-scssroot": {
-      "version": "git://github.com/totten/civicrm-scssroot.git#3fc126e91ea503420daedc82425e9b85085707f6",
-      "from": "git://github.com/totten/civicrm-scssroot.git#v0.1.1",
+      "version": "github:totten/civicrm-scssroot#3fc126e91ea503420daedc82425e9b85085707f6",
+      "from": "github:totten/civicrm-scssroot#v0.1.1",
       "dev": true,
       "requires": {
         "civicrm-cv": "^0.1.2"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/compucorp/uk.co.compucorp.civicrm.prospect#readme",
   "devDependencies": {
     "civicrm-cv": "^0.1.2",
-    "civicrm-scssroot": "git://github.com/totten/civicrm-scssroot.git#v0.1.1",
+    "civicrm-scssroot": "totten/civicrm-scssroot#v0.1.1",
     "eslint": "^6.5.1",
     "eslint-config-semistandard": "^15.0.0",
     "eslint-config-standard": "^14.1.0",

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -1,6 +1,21 @@
 <?xml version="1.0"?>
 <ruleset name="PHP Custom Ruleset">
-  <description>Civicrm Coder Ruleset</description>
-  <rule ref="bin/civicrm/coder/coder_sniffer/Drupal">
-  </rule>
+    <description>Drupal Coder Ruleset with some exclusions</description>
+    <rule ref="bin/drupal/coder/coder_sniffer/Drupal">
+        <!-- CiviCRM expects to have file names with underscores -->
+        <!-- Example: The Class `CRM_CiviAwards_Upgrader` has a file name of `Upgrader.php` -->
+        <!-- Hence the following rules are excluded -->
+        <exclude name="Drupal.NamingConventions.ValidClassName.NoUnderscores"/>
+        <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
+        <exclude name="Drupal.Classes.ClassFileName.NoMatch"/>
+        <!--Drupal expects function names like civiawards_civicrm_pre_process but civi can have-->
+        <!--civiawards_civicrm_preProcess which is valid for civi.-->
+        <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
+        <!-- this was was added in drupal, but in civicrm we ignore this rule -->
+        <exclude name="Drupal.Classes.UseGlobalClass.RedundantUseStatement"/>
+        <!-- These files are mainly auto generated and has some rules we want to exclude -->
+        <exclude-pattern>CRM/Prospect/DAO/*</exclude-pattern>
+        <exclude-pattern>civiawards.civix.php</exclude-pattern>
+        <exclude-pattern>CRM/Prospect/Upgrader/Base.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -3,6 +3,6 @@
   <description>CiviCRM Coder Ruleset</description>
   <rule ref="bin/civicrm/coder/coder_sniffer/Drupal"></rule>
   <exclude-pattern>tests/phpunit/bootstrap.php</exclude-pattern>
-  <exclude-pattern>membershipextras.civix.php</exclude-pattern>
-  <exclude-pattern>CRM/MembershipExtras/Upgrader/Base.php</exclude-pattern>
+  <exclude-pattern>prospect.civix.php</exclude-pattern>
+  <exclude-pattern>CRM/Prospect/Upgrader/Base.php</exclude-pattern>
 </ruleset>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -1,21 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="PHP Custom Ruleset">
-    <description>Drupal Coder Ruleset with some exclusions</description>
-    <rule ref="bin/drupal/coder/coder_sniffer/Drupal">
-        <!-- CiviCRM expects to have file names with underscores -->
-        <!-- Example: The Class `CRM_CiviAwards_Upgrader` has a file name of `Upgrader.php` -->
-        <!-- Hence the following rules are excluded -->
-        <exclude name="Drupal.NamingConventions.ValidClassName.NoUnderscores"/>
-        <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
-        <exclude name="Drupal.Classes.ClassFileName.NoMatch"/>
-        <!--Drupal expects function names like civiawards_civicrm_pre_process but civi can have-->
-        <!--civiawards_civicrm_preProcess which is valid for civi.-->
-        <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
-        <!-- this was was added in drupal, but in civicrm we ignore this rule -->
-        <exclude name="Drupal.Classes.UseGlobalClass.RedundantUseStatement"/>
-        <!-- These files are mainly auto generated and has some rules we want to exclude -->
-        <exclude-pattern>CRM/Prospect/DAO/*</exclude-pattern>
-        <exclude-pattern>civiawards.civix.php</exclude-pattern>
-        <exclude-pattern>CRM/Prospect/Upgrader/Base.php</exclude-pattern>
-    </rule>
+  <description>CiviCRM Coder Ruleset</description>
+  <rule ref="bin/civicrm/coder/coder_sniffer/Drupal"></rule>
+  <exclude-pattern>tests/phpunit/bootstrap.php</exclude-pattern>
+  <exclude-pattern>membershipextras.civix.php</exclude-pattern>
+  <exclude-pattern>CRM/MembershipExtras/Upgrader/Base.php</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
## Overview
The extension fails during the installation process in hook `MoveCustomFieldsToWorkFlowCaseType`. this was caused by an API exception `Supplied Sub type is not valid for the specified entity.` thrown by the CustomGroup API when updating the prospect custom types.

## Before
_installation fails_

## After
_installation succeeds_

## Technical Details
This error was caused by a strict validation added to the CustomGroup create API in this PR https://github.com/civicrm/civicrm-core/pull/20616, it requires that when creating a CustomGroup the `extends_entity_column_value` ID should be a child of the 'extends' column. so, trying to Update a CustomGroup that extends `case` and `extends_entity_column_value` ids are ids of a Prospect Case type and not a direct case type. we resolve this error by using the `custom group` object instead of the API to update the prospect custom groups. similar approach is used in CiviCase and CiviAwards https://github.com/compucorp/uk.co.compucorp.civicase/blob/d5e096fd11b0c65ebe91a7ef2cf9cbe18617e544/CRM/Civicase/Service/BaseCaseTypePostProcessor.php#L34-L46

This PR also fix the failing unit test and linter action, one is caused by the node version used by the GitHub action, and it is fixed by instructing the action to read the node version from the .nvmrc file, and the other error is:

```
npm ERR! Error while executing:
npm ERR! /usr/bin/git ls-remote -h -t git://github.com/totten/civicrm-scssroot.git
npm ERR! 
npm ERR! fatal: remote error: 
npm ERR!   The unauthenticated git protocol on port 9418 is no longer supported.
```

This error is fixed by changing the civicrm-scssroot git URL to the newly supported [Github URL](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#github-urls).