### PR TITLE
MAE-894: Use PHP8 and CiviCRM 5.51.3 in test workflow

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.1.1-php7.2-chrome
+    container: compucorp/civicrm-buildkit:1.3.0-php8.0-chrome
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -31,7 +31,15 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.35 --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.79 --web-root $GITHUB_WORKSPACE/site
+
+      - uses: compucorp/apply-patch@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repo: compucorp/civicrm-core
+          version: 5.51.3
+          path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2
         with:
@@ -40,9 +48,9 @@ jobs:
       - name: Download CiviProspect dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.usermenu.git
+          git clone -b MAE-847-php8 --depth 1 https://github.com/compucorp/uk.co.compucorp.usermenu.git
           git clone --depth 1 https://github.com/civicrm/org.civicrm.shoreditch.git
-          git clone --depth 1 --no-single-branch https://github.com/compucorp/uk.co.compucorp.civicase.git
+          git clone --depth 1 -b MAE-823-align-with-civi-5.51.3 --no-single-branch https://github.com/compucorp/uk.co.compucorp.civicase.git
 
       - name: Switch Civicase Branch
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase

--- a/CRM/Prospect/Helper/ProspectConverted.php
+++ b/CRM/Prospect/Helper/ProspectConverted.php
@@ -19,7 +19,7 @@ class CRM_Prospect_Helper_ProspectConverted {
    * @param int $paymentTypeId
    *   Payment Type ID.
    */
-  public function create($paymentEntityId, $paymentTypeId) {
+  public static function create($paymentEntityId, $paymentTypeId) {
     $caseId = CRM_Utils_Request::retrieve('caseId', 'Integer');
 
     if (!$caseId) {


### PR DESCRIPTION
## Overview

Aside from updating the test container to the PHP8 version, there was the following error appearing in the logs:

```
php_1      | [27-Sep-2022 13:25:36] WARNING: [pool www] child 26443 said into stderr: "NOTICE: PHP message: Xdebug: [Step Debug] Time-out connecting to debugging client, waited: 200 ms. Tried: 172.30.0.1:9003 (from REMOTE_ADDR HTTP header), host.docker.internal:9003 (fallback through xdebug.client_host/xdebug.client_port) :-("
php_1      | Sep 27 13:25:35 php ccphp83_localhost:3977-drupal: 1664281535|172.30.0.1|http://ccphp83.localhost:3977/|php
|http://ccphp83.localhost:3977/civicrm/contact/view/membership?action=add&cid=5&context=membership&snippet=json%7Chttp://ccphp83.localhost:3977/civicrm/contact/view?reset=1&cid=5&selectedChild=member
|1||Error: Non-static method CRM_Prospect_Helper_ProspectConverted::create() cannot be called statically in CRM_Prospect_Hook_Post_ConvertContributionToProspect->run() 
(line 29 of /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/uk.co.compucorp.civicrm.prospect/CRM/Prospect/Hook/Post/ConvertContributionToProspect.php)
```

which is solved here: https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/pull/101/commits/88cc3ef9eb6ed9939c0463612954960308e9f452