### PR TITLE
CIVIIB-114: Fix running upgrader on PHP 8 sites

### DIFF
--- a/CRM/Prospect/Upgrader.php
+++ b/CRM/Prospect/Upgrader.php
@@ -198,7 +198,7 @@ class CRM_Prospect_Upgrader extends CRM_Prospect_Upgrader_Base {
    *   The queue requires that true is returned on successful upgrade, but we
    *   use exceptions to indicate an error instead.
    */
-  public function runStepUpgrade(CRM_Queue_TaskContext $context, $step) {
+  public static function runStepUpgrade(CRM_Queue_TaskContext $context, $step) {
     $step->apply();
 
     return TRUE;


### PR DESCRIPTION
## Overview
This pull request addresses the issue with the error that happens when running the extension upgrader on PHP 8 sites. The changes made to the `CRM/Prospect/Upgrader.php` file include modifying the `runStepUpgrade` method from non-static to static.

see This [PR](https://github.com/compucorp/uk.co.compucorp.civiawards/pull/269) for more details.

