### PR TITLE
GIZ-348: Prevent accessing paymentinfo if not on prospect

### DIFF
--- a/ang/prospect/case-actions/services/unlink-contribution-case-action.service.js
+++ b/ang/prospect/case-actions/services/unlink-contribution-case-action.service.js
@@ -15,7 +15,7 @@
      * @returns {boolean} if action is allowed
      */
     this.isActionAllowed = function (action, cases) {
-      if (!cases[0] || !cases[0].prospect.paymentInfo) {
+      if (!cases[0] || !cases[0].prospect || !cases[0].prospect.paymentInfo) {
         return;
       }
 

--- a/ang/prospect/case-actions/services/view-pledge-contribution-case-action.service.js
+++ b/ang/prospect/case-actions/services/view-pledge-contribution-case-action.service.js
@@ -19,7 +19,7 @@
      * @returns {boolean} if action is allowed
      */
     this.isActionAllowed = function (action, cases) {
-      if (!cases[0] || !cases[0].prospect.paymentInfo) {
+      if (!cases[0] || !cases[0].prospect || !cases[0].prospect.paymentInfo) {
         return;
       }
 


### PR DESCRIPTION
## Overview
Multiple errors are thrown when accessing a none Prospect summary tab on the contact dashboard. This PR resolves this issue.

## Before
<img width="1268" alt="Screenshot 2023-06-30 at 12 31 13" src="https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/assets/85277674/6f97a942-20c8-451e-9be7-2cee08c86819">


## After
<img width="1252" alt="Screenshot 2023-06-30 at 13 11 00" src="https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/assets/85277674/0df5e6b8-2427-475b-b4e1-44d4a4af2d02">

## Technical Details
The PaymentInfo field is specific to the Prospect case type category and is related to the conversion of a Prospect to either a pledge or contribution. You can refer to this [PR](https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/pull/29) where the payment information field was added.

Within the prospect case type category, there are two case actions provided: one for unlinking a prospect from a contribution and another for viewing the associated contribution. With conditions that ensure these actions are only added if the case/prospect has payment information. 

Unfortunately, there is a bug in the current conditions where the code tries to access the `paymentinfo` of the prospect object without first checking if the `prospect` object is defined.

```js
if (!cases[0] || !cases[0].prospect.paymentInfo) {
  return;
}
```
Hence causing the error:
`TypeError: Cannot read properties of undefined (reading 'paymentInfo')
at UnlinkContributionCaseAction.isActionAllowed`

To resolve this issue, the proposed PR includes a fix by defining the prospect object before attempting to access its `paymentinfo` field. Here is the updated code snippet:

```js
if (!cases[0] || !cases[0].prospect || !cases[0].prospect.paymentInfo) {
  return;
}
```

This change ensures that the code checks the existence of the `prospect` object before accessing its `paymentinfo` field, effectively resolving the bug.