### PR TITLE
COMCL-1218: Fix prospect creation

### DIFF
--- a/CRM/Prospect/ProspectCustomGroups.php
+++ b/CRM/Prospect/ProspectCustomGroups.php
@@ -267,19 +267,13 @@ class CRM_Prospect_ProspectCustomGroups {
     // from Request array and then convert it into CiviCRM date format.
     if ($dataType === 'Date') {
       if (method_exists('CRM_Utils_Request', 'retrieveValue')) {
-        $dateArray = [
-          'value' => CRM_Utils_Request::retrieveValue($fieldKey, 'String', NULL, FALSE, CRM_Utils_Request::exportValues()),
-        ];
+        $date = CRM_Utils_Request::retrieveValue($fieldKey, 'String', NULL, FALSE, CRM_Utils_Request::exportValues());
       }
       else {
-        $dateArray = [
-          'value' => CRM_Utils_Array::value($fieldKey, CRM_Utils_Request::exportValues()),
-        ];
+        $date = CRM_Utils_Array::value($fieldKey, CRM_Utils_Request::exportValues());
       }
 
-      CRM_Utils_Date::convertToDefaultDate($dateArray, 1, 'value');
-
-      $value = $dateArray['value'];
+      $value = ($date !== NULL && $date !== '') ? CRM_Utils_Date::customFormat(CRM_Utils_Date::processDate($date), '%Y%m%d') : NULL;
     }
 
     return $value;


### PR DESCRIPTION
## Overview
This Pr fixes a bug that restricted the user from creating new prospects.

## Before
An error was shown to user upon creating new prospect
![screen_recording_before](https://github.com/user-attachments/assets/a70eb48c-14dd-4ce1-9e19-6e023fda56f6)


## After
Prospect is now created successfully
![screen_recording_after](https://github.com/user-attachments/assets/c092e954-a167-418e-aaeb-5ec9b1f0a1a2)


## Technical Details
This issue occurred after upgrading civicrm to 6.4.1  due to the fact that one class in this extension was using a date function which got removed in new civicrm function. This PR replaces the usage of that function with an alternative function.
