### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Prospect/BAO/ProspectConverted.php
+++ b/CRM/Prospect/BAO/ProspectConverted.php
@@ -106,7 +106,7 @@ class CRM_Prospect_BAO_ProspectConverted extends CRM_Prospect_DAO_ProspectConver
       $result = civicrm_api3('Contribution', 'getsingle', [
         'id' => $id,
       ]);
-    } catch (CiviCRM_API3_Exception $e) {}
+    } catch (CRM_Core_Exception $e) {}
 
     return $result;
   }
@@ -125,7 +125,7 @@ class CRM_Prospect_BAO_ProspectConverted extends CRM_Prospect_DAO_ProspectConver
       $result = civicrm_api3('Pledge', 'getsingle', [
         'id' => $id,
       ]);
-    } catch (CiviCRM_API3_Exception $e) {}
+    } catch (CRM_Core_Exception $e) {}
 
     return $result;
   }

--- a/CRM/Prospect/CustomFieldsFormBuilder.php
+++ b/CRM/Prospect/CustomFieldsFormBuilder.php
@@ -70,7 +70,7 @@ class CRM_Prospect_CustomFieldsFormBuilder {
 
       $customGroupId = $customGroupResult['id'];
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
     }
 
     return $customGroupId;

--- a/CRM/Prospect/Form/Handler/PaymentEntityUpdate.php
+++ b/CRM/Prospect/Form/Handler/PaymentEntityUpdate.php
@@ -41,7 +41,7 @@ class CRM_Prospect_Form_Handler_PaymentEntityUpdate {
 
       $form->assign('caseID', $prospectConverted['prospect_case_id']);
       $form->assign('prospectFinancialInformationFields', new CRM_Prospect_prospectFinancialInformationFields($prospectConverted['prospect_case_id']));
-    } catch (CiviCRM_API3_Exception $e) {}
+    } catch (CRM_Core_Exception $e) {}
   }
 
   /**

--- a/CRM/Prospect/Hook/Post/UpdateProspectFields.php
+++ b/CRM/Prospect/Hook/Post/UpdateProspectFields.php
@@ -71,7 +71,7 @@ class CRM_Prospect_Hook_Post_UpdateProspectFields {
         'Substatus',
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       CRM_Core_Session::setStatus(
         ts('Cannot find Case entry. The Case didn\'t get created properly or there is other issue with retrieving the Case.'),
         ts('Error updating Expectation value'),

--- a/CRM/Prospect/ProspectCustomGroups.php
+++ b/CRM/Prospect/ProspectCustomGroups.php
@@ -241,7 +241,7 @@ class CRM_Prospect_ProspectCustomGroups {
 
       return $option['label'];
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       return NULL;
     }
   }

--- a/api/v3/ProspectConverted.php
+++ b/api/v3/ProspectConverted.php
@@ -14,7 +14,7 @@
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_prospect_converted_create(array $params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -29,7 +29,7 @@ function civicrm_api3_prospect_converted_create(array $params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_prospect_converted_delete(array $params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -44,7 +44,7 @@ function civicrm_api3_prospect_converted_delete(array $params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_prospect_converted_get(array $params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -74,7 +74,7 @@ function _civicrm_api3_prospect_converted_getpaymentinfo_spec(array &$params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_prospect_converted_getpaymentinfo(array $params) {
   $prospectConverted = CRM_Prospect_BAO_ProspectConverted::findByCaseID($params['prospect_case_id']);


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.